### PR TITLE
Change links to point to the right place

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -128,9 +128,9 @@
             </div>
         </div>
         <div id="footer">
-            <a href="https://github.com" target="_blank">GitHub</a>
+            <a href="https://github.com/alyssaxuu/flowy" target="_blank">GitHub</a>
             <span>·</span>
-            <a href="https://github.com" target="_blank">Twitter</a>
+            <a href="https://twitter.com/alyssaxuu" target="_blank">Twitter</a>
             <span>·</span>
                 <a href="https://alyssax.com" target="_blank"><p>Made with</p><img src="assets/heart.svg"><p>by</p> Alyssa X</a>
         </div>


### PR DESCRIPTION
I opened the demo, played around, and then clicked the GitHub link expecting to come back to the repo, but it currently points to the GitHub homepage. This PR updates that to point back here, and adds a Twitter link as well. :)

(Obviously, it's a demo app that doesn't need to have all the functionality, but the GitHub link in particular was a little confusing. :) )