### PR TITLE
Fixed a drag and drop issue

### DIFF
--- a/engine/flowy.js
+++ b/engine/flowy.js
@@ -104,7 +104,7 @@ var flowy = function(canvas, grab, release, snapping, spacing_x, spacing_y) {
                 drag.classList.add("dragging");
                 active = true;
                 dragx = mouse_x - (event.target.closest(".create-flowy").offsetLeft);
-                dragy = mouse_y - (event.target.closest(".create-flowy").offsetTop);
+                dragy = mouse_y - (event.target.closest(".create-flowy").offsetTop - event.target.closest(".create-flowy").parentNode.scrollTop);
                 drag.style.left = mouse_x - dragx + "px";
                 drag.style.top = mouse_y - dragy + "px";
             }


### PR DESCRIPTION
Fixed a drag and drop issue in the engine when the container of blocks is loaded with a lot of blocks. In that case, when we try to drag and drop an element from the bottom of the list it disappears. 

To reproduce this bug, just fill the container of blocks with a lot of blocks and scroll down to the bottom and try to drag and drop the last one for example.