### PR TITLE
Allow Snapping to have an empty return

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ function onRelease(){
 	// When the user releases a block
 }
 function onSnap(block, first, parent){
-	// When a block snaps with another one
+	// When a block can attach to a parent
+	return true;
 }
 function onRearrange(block, parent){
 	// When a block is rearranged

--- a/engine/flowy.js
+++ b/engine/flowy.js
@@ -637,7 +637,11 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
     }
 
     function blockSnap(drag, first, parent) {
-        return snapping(drag, first, parent);
+        var hasSnap = snapping(drag, first, parent);
+        if (hasSnap !== undefined) {
+            return hasSnap
+        }
+        return true;
     }
 
     function beforeDelete(drag, parent) {


### PR DESCRIPTION
I created a function without a return value. this lead to the error of "x" being undefined and the parent not being recognized.
And since all other functions don't need a return value, I thought one may handle the empty function within the repository.

In my opinion the snap should be explicitly disallowed by returning false. Most likely this can be seen as a design choice.
So it may not be to your liking. Since the changes are minimal I thought I would go ahead and make a PR.