### PR TITLE
PMM Workflow Designer: bug fixes, zoom, XSS hardening, and branching starter flow

### DIFF
--- a/CODEX_HANDOFF.md
+++ b/CODEX_HANDOFF.md
@@ -79,6 +79,175 @@ A drag-and-drop workflow designer for Product Marketing Managers, built on top o
 
 ---
 
+## Feature request — Canvas Zoom (2026-05-03)
+
+### Design
+
+**Goal:** Let users zoom in/out on the workflow canvas to navigate large trees without scrolling everywhere.
+
+**UI — floating zoom pill (bottom-right of canvas)**
+```
+[ − ]  [ 100% ]  [ + ]  [ ⊡ ]
+```
+- Positioned `absolute; bottom: 12px; right: 12px; z-index: 10` inside `#canvas-wrap`
+- `−` decreases zoom by 25%, `+` increases by 25%, `⊡` resets to 100%
+- Percentage label is read-only, shows current zoom (e.g. `75%`)
+- Ctrl/Cmd + scroll wheel on the canvas also zooms in/out (25% step, preventDefault)
+- Zoom range: **25% – 200%**. Clamp at both ends, disable the button at the limit.
+
+**HTML to add in `demo/index.html`** (inside `<section id="canvas-wrap">`, after `<div id="canvas">`):
+```html
+<div id="zoom-controls">
+  <button id="zoom-out" title="Zoom out">−</button>
+  <span id="zoom-label">100%</span>
+  <button id="zoom-in" title="Zoom in">+</button>
+  <button id="zoom-reset" title="Reset zoom">⊡</button>
+</div>
+```
+
+**CSS to add in `demo/styles.css`:**
+```css
+#zoom-controls {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255,255,255,0.92);
+  border: 1px solid #d5d7c8;
+  border-radius: 8px;
+  padding: 4px 8px;
+  backdrop-filter: blur(6px);
+}
+#zoom-controls button {
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+#zoom-controls button:hover { background: #f2f2ec; }
+#zoom-controls button:disabled { opacity: 0.35; cursor: default; }
+#zoom-label {
+  font-size: 12px;
+  min-width: 36px;
+  text-align: center;
+  color: #3d4033;
+  font-weight: 500;
+}
+```
+
+**Coordinate math — why zoom must be threaded into flowy**
+
+`flowy.js` reads `event.clientX/Y` for mouse position and `el.getBoundingClientRect()` for block positions. When the canvas content is CSS-scaled, `getBoundingClientRect()` returns *scaled* pixel values, so all snap/attach/layout math drifts by the zoom factor. The fix: divide every mouse coordinate and every `getBoundingClientRect` result by the current zoom level inside flowy.
+
+**Implementation plan (3 files)**
+
+### 1. `engine/flowy.js`
+
+Add a module-level zoom variable and expose a setter:
+
+```js
+// near top of flowy.load(), before the existing vars:
+var zoom = 1;
+flowy.setZoom = function(level) { zoom = level; };
+```
+
+Everywhere flowy reads a mouse position (there are exactly 4 places — `beginDrag`, `moveBlock`, and `touchblock`), divide by zoom:
+
+```js
+// beginDrag (~line 129)
+mouse_x = event.changedTouches[0].clientX / zoom;
+mouse_y = event.changedTouches[0].clientY / zoom;
+// ... and the else branch:
+mouse_x = event.clientX / zoom;
+mouse_y = event.clientY / zoom;
+
+// moveBlock (~line 435) — same pattern, both touch and mouse branches
+// touchblock (~line 407) — same pattern
+```
+
+Everywhere flowy calls `.getBoundingClientRect()` on a **drag element** (not canvas_div — that stays in screen space), divide the result by zoom. The safest way: add a helper inside `flowy.load()`:
+
+```js
+function scaled(rect) {
+  return {
+    left:   rect.left   / zoom,
+    top:    rect.top    / zoom,
+    right:  rect.right  / zoom,
+    bottom: rect.bottom / zoom,
+    width:  rect.width  / zoom,
+    height: rect.height / zoom
+  };
+}
+```
+
+Then replace every `drag.getBoundingClientRect()` and `blockParent.getBoundingClientRect()` call with `scaled(drag.getBoundingClientRect())` etc. **Do not** scale `canvas_div.getBoundingClientRect()` — it is in screen space and should stay unscaled.
+
+### 2. `demo/index.html`
+
+Add the zoom controls HTML block inside `<section id="canvas-wrap">`, after `<div id="canvas">`:
+
+```html
+<div id="zoom-controls">
+  <button id="zoom-out" title="Zoom out">−</button>
+  <span id="zoom-label">100%</span>
+  <button id="zoom-in" title="Zoom in">+</button>
+  <button id="zoom-reset" title="Reset zoom">⊡</button>
+</div>
+```
+
+### 3. `demo/main.js`
+
+Add zoom state and wiring inside the `DOMContentLoaded` callback, after the `flowy(...)` init call:
+
+```js
+// Zoom
+let zoomLevel = 1.0;
+const ZOOM_STEP = 0.25;
+const ZOOM_MIN  = 0.25;
+const ZOOM_MAX  = 2.0;
+const canvas    = document.getElementById('canvas');  // already declared above
+
+function applyZoom(level) {
+  zoomLevel = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level));
+  canvas.style.transform       = `scale(${zoomLevel})`;
+  canvas.style.transformOrigin = '0 0';
+  // Expand canvas-wrap scroll area so scrollbars reflect full scaled size
+  canvas.style.width  = `${100 / zoomLevel}%`;
+  canvas.style.height = `${100 / zoomLevel}%`;
+  document.getElementById('zoom-label').textContent = `${Math.round(zoomLevel * 100)}%`;
+  document.getElementById('zoom-out').disabled   = zoomLevel <= ZOOM_MIN;
+  document.getElementById('zoom-in').disabled    = zoomLevel >= ZOOM_MAX;
+  flowy.setZoom(zoomLevel);
+}
+
+document.getElementById('zoom-in').addEventListener('click',    () => applyZoom(zoomLevel + ZOOM_STEP));
+document.getElementById('zoom-out').addEventListener('click',   () => applyZoom(zoomLevel - ZOOM_STEP));
+document.getElementById('zoom-reset').addEventListener('click', () => applyZoom(1.0));
+
+document.getElementById('canvas-wrap').addEventListener('wheel', (e) => {
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault();
+    applyZoom(zoomLevel + (e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP));
+  }
+}, { passive: false });
+```
+
+### Acceptance criteria
+- [ ] Zoom in/out/reset buttons appear bottom-right of canvas
+- [ ] Ctrl/Cmd+scroll wheel adjusts zoom on the canvas
+- [ ] Buttons disable at 25% and 200% limits
+- [ ] Drag-and-drop still works correctly at all zoom levels (block snaps to correct parent)
+- [ ] "Build Starter Flow" renders correctly at non-100% zoom
+- [ ] Zoom state does NOT persist to localStorage (always resets to 100% on reload)
+
+---
+
 ## ~~Open issue — branching tree not rendering~~ — RESOLVED (2026-05-03)
 
 **Root cause:** `flowy.import()` in `engine/flowy.js` calls `rearrangeMe()` and `checkOffset()` after setting `canvas_div.innerHTML`. `rearrangeMe()` recalculates and overwrites every block's `left`/`top` using flowy's own linear stacking algorithm — completely discarding the custom tree positions set in `buildStarterFlowImport`. Branching nodes all get stacked in a single vertical column.

--- a/CODEX_HANDOFF.md
+++ b/CODEX_HANDOFF.md
@@ -1,0 +1,362 @@
+# Codex Handoff — PMM Agentic Workflow Designer
+
+## Implementation log
+
+**2026-05-03 — All 12 fixes applied by Codex and synced.**
+
+| # | Fix | Status |
+|---|-----|--------|
+| 1 | `r_array[0].y` in `rearrangeMe` | ✅ Done |
+| 2 | Bottom-edge `scrollTop` typo | ✅ Done |
+| 3 | Empty canvas clears localStorage | ✅ Done |
+| 4 | XSS via innerHTML — replaced with `createElement` + `textContent` | ✅ Done |
+| 5 | Analytics label → ID matching | ✅ Done |
+| 6 | `innerHTML +=` → `insertAdjacentHTML` in `drawArrow` | ✅ Done |
+| 7 | Silent catch blocks now log errors | ✅ Done |
+| 8 | Form input debounced at 150ms | ✅ Done |
+| 9 | Int/string type mismatch in `snap` rearrange | ✅ Done |
+| 10 | `flowy.destroy()` cleanup method added | ✅ Done |
+| 11 | Hot-path `.filter()` calls cached per loop | ✅ Done |
+| 12 | Dead code removed (`addEventListenerMulti`, `removeEventListenerMulti`, `maxheight`) | ✅ Done |
+
+Both files passed `node --check` syntax validation. Fixed files synced to `/Users/cashclaw/Documents/New project 5`.
+
+**2026-05-03 — Starter workflow expanded to 14 steps by Codex.**
+
+Replaced the 7-step placeholder in `demo/main.js` (`build-starter` handler) with a full end-to-end PMM launch lifecycle:
+
+| # | Step | Owner | Bucket | Risk |
+|---|------|-------|--------|------|
+| 1 | Market & Competitive Research | PMM Lead | assist | medium |
+| 2 | Customer & ICP Discovery | PMM + UX Researcher | human | medium |
+| 3 | Positioning Workshop | PMM Lead + CPO | human | high |
+| 4 | Messaging Architecture | PMM Lead | human | high |
+| 5 | Message Testing & Validation | PMM + Demand Gen | assist | medium |
+| 6 | Go-to-Market Strategy | PMM Lead + VP Marketing | human | high |
+| 7 | Content Brief Creation | PMM | assist | low |
+| 8 | Sales Enablement Kit | PMM + Sales Ops | assist | medium |
+| 9 | Launch Asset Production | Content Team + PMM | assist | medium |
+| 10 | Analyst & Press Briefings | PMM Lead + PR | human | high |
+| 11 | Internal Launch Readiness | PMM + RevOps | assist | low |
+| 12 | Launch Execution | PMM + Demand Gen + PR | assist | high |
+| 13 | Localization & Regional Adaptation | PMM + Regional Leads | agent | medium |
+| 14 | Post-Launch Performance Review | PMM Lead + Analytics | assist | low |
+
+Click **"Build Starter Flow"** in the app to load this workflow for editing.
+
+**2026-05-03 — Expanded to full branching PMM workflow tree (21 nodes) by Codex.**
+
+Replaced the linear 14-step chain with a trunk + 4 operational branches. `buildStarterFlowImport` now uses a recursive subtree-width centering layout (root x=600 y=160, +220px depth, 320px sibling gap).
+
+**Trunk — Launch Lifecycle (IDs 0–7, linear)**
+Market Research → ICP Discovery → Positioning Workshop → Messaging Architecture → GTM Strategy → Launch Assets → Launch Execution → Post-Launch Review
+
+**Branch A — Ongoing Competitive Intel (IDs 8–10, off ID 0)**
+Weekly Signal Scan → Battlecard Refresh → Sales Alert Broadcast
+
+**Branch B — Content Calendar Loop (IDs 11–14, off ID 5)**
+Monthly Content Planning → SEO & Keyword Review → Content Production Briefing → Multi-Channel Publishing
+
+**Branch C — Win/Loss & Pipeline Review (IDs 15–17, off ID 7)**
+Weekly Win/Loss Pull → Messaging Resonance Analysis → Quarterly Positioning Refresh
+
+**Branch D — Sales Enablement Ops (IDs 18–20, off ID 4)**
+Sales Feedback Collection → Enablement Asset Update → Sales Training Session
+
+`node --check` passes. Synced to `/Users/cashclaw/Documents/New project 5`.
+
+---
+
+## Project overview
+
+A drag-and-drop workflow designer for Product Marketing Managers, built on top of the open-source **Flowy.js** library. Users compose workflow graphs from template blocks, assign metadata (owner, tool, risk, automation %), and get live analytics on workload and automation potential.
+
+**Key files:**
+- `engine/flowy.js` — core drag-and-drop engine (third-party, lightly modified)
+- `demo/main.js` — application logic (block hydration, analytics, persistence)
+- `demo/index.html` — single-page UI
+- `demo/styles.css` — layout and component styles
+
+---
+
+## ~~Open issue — branching tree not rendering~~ — RESOLVED (2026-05-03)
+
+**Root cause:** `flowy.import()` in `engine/flowy.js` calls `rearrangeMe()` and `checkOffset()` after setting `canvas_div.innerHTML`. `rearrangeMe()` recalculates and overwrites every block's `left`/`top` using flowy's own linear stacking algorithm — completely discarding the custom tree positions set in `buildStarterFlowImport`. Branching nodes all get stacked in a single vertical column.
+
+**Secondary cause:** `restore()` on DOMContentLoaded loads the last-saved flow from localStorage, so clicking "Build Starter Flow" while stale data is cached appears to do nothing until localStorage is cleared.
+
+### Fix 1 — Skip rearrangeMe on import (`engine/flowy.js`)
+
+Add a `skipRearrange` parameter to `flowy.import` so callers that supply pre-positioned HTML can opt out:
+
+```js
+// engine/flowy.js — inside flowy.load()
+flowy.import = function(output, skipRearrange) {
+    canvas_div.innerHTML = output.html;
+    for (var a = 0; a < output.blockarr.length; a++) {
+        blocks.push({
+            childwidth: parseFloat(output.blockarr[a].childwidth),
+            parent: parseFloat(output.blockarr[a].parent),
+            id: parseFloat(output.blockarr[a].id),
+            x: parseFloat(output.blockarr[a].x),
+            y: parseFloat(output.blockarr[a].y),
+            width: parseFloat(output.blockarr[a].width),
+            height: parseFloat(output.blockarr[a].height)
+        });
+    }
+    if (!skipRearrange && blocks.length > 1) {
+        rearrangeMe();
+        checkOffset();
+    }
+}
+```
+
+### Fix 2 — Pass `skipRearrange=true` from the build-starter handler (`demo/main.js`)
+
+```js
+// demo/main.js — inside build-starter click handler
+flowy.import(buildStarterFlowImport(blocks), true);   // ← add second arg
+```
+
+### Fix 3 — Also pass `skipRearrange=true` from restore() to preserve saved layouts
+
+```js
+// demo/main.js — inside restore()
+flowy.import(JSON.parse(raw), true);
+```
+
+### Fix 4 — Clear localStorage before loading starter flow
+
+In the build-starter click handler, clear the saved key before importing so restore() on the next page load shows the new tree, not the old linear flow:
+
+```js
+document.getElementById("build-starter").addEventListener("click", () => {
+    flowy.deleteBlocks();
+    selectedBlock = null;
+    localStorage.removeItem(STORAGE_KEY);   // ← add this line
+    const blocks = [ ... ];
+    flowy.import(buildStarterFlowImport(blocks), true);
+    ...
+});
+```
+
+**Files to change:** `engine/flowy.js` (Fix 1) and `demo/main.js` (Fixes 2–4).  
+**Do not change** the `buildStarterFlowImport` layout logic or the blocks array — those are correct.
+
+---
+
+## Bugs to fix
+
+### 1. `rearrangeMe` uses array object instead of array element — blocks misplace on rearrange
+**File:** `engine/flowy.js` lines 596–607  
+`blocks.filter()` returns an array `[]`, but the code reads and writes `.y` directly on that array instead of `[0].y`. Block positions become `NaN` after any rearrange.
+
+```js
+// Current (broken)
+const r_array = blocks.filter(id => id.id == result[z]);
+r_block.style.top = r_array.y + paddingy + canvas_div.getBoundingClientRect().top - absy + "px";
+r_array.y = r_array.y + paddingy;
+r_block.style.left = r_array[0].x - ...  // inconsistent — some lines already use [0]
+
+// Fix: use r_array[0] consistently
+r_block.style.top = r_array[0].y + paddingy + canvas_div.getBoundingClientRect().top - absy + "px";
+r_array[0].y = r_array[0].y + paddingy;
+```
+
+### 2. Bottom-edge auto-scroll uses wrong axis
+**File:** `engine/flowy.js` line 514  
+When the cursor hits the bottom edge of the canvas, the code scrolls `scrollLeft` instead of `scrollTop`.
+
+```js
+// Current (broken)
+} else if (mouse_y < canvas_div.getBoundingClientRect().top + 10 && mouse_y > canvas_div.getBoundingClientRect().top - 10) {
+    canvas_div.scrollLeft -= 10;
+
+// Fix
+    canvas_div.scrollTop -= 10;
+```
+
+### 3. Rearrange snap has int/string type mismatch
+**File:** `engine/flowy.js` line 329  
+All other `blockstemp.filter` calls use `parseInt()` on the `.value`, but this one does not — the `==` coercion may silently fail to find the block in strict environments or after refactoring.
+
+```js
+// Current
+blockstemp.filter(a => a.id == drag.querySelector(".blockid").value)[0].parent = blocko[i];
+
+// Fix
+blockstemp.filter(a => a.id === parseInt(drag.querySelector(".blockid").value))[0].parent = blocko[i];
+```
+
+### 4. Analytics auto-correct matches blocks by label instead of ID
+**File:** `demo/main.js` lines 157–160  
+When a high-risk block is missing an approval gate, the fix iterates all canvas blocks and matches by `label` string. Two blocks with identical labels both get mutated.
+
+```js
+// Current (fragile)
+document.querySelectorAll("#canvas .block").forEach((node) => {
+  if (getField(node, "label") === b.dataMap.label) {
+    setField(node, "approval", "true");
+  }
+});
+
+// Fix: match by block id
+document.querySelectorAll("#canvas .block").forEach((node) => {
+  if (parseInt(getField(node, "blockid")) === b.id) {
+    setField(node, "approval", "true");
+  }
+});
+```
+
+### 5. Clearing the canvas doesn't clear localStorage
+**File:** `demo/main.js` lines 271–275  
+`persist()` bails early when `flowy.output()` returns falsy (empty canvas), leaving the previous flow in localStorage. On next page load the cleared canvas is restored.
+
+```js
+// Current
+function persist() {
+  const out = flowy.output();
+  if (!out) return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(out));
+}
+
+// Fix
+function persist() {
+  const out = flowy.output();
+  if (!out) {
+    localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(out));
+}
+```
+
+---
+
+## Security fixes
+
+### 6. XSS via innerHTML string interpolation
+**Files:** `demo/main.js` lines 87–93, 207–229  
+`hydrateBlock` and `buildStarterFlowImport` interpolate user-controlled values (`step.label`, `step.person`, `step.tool`, `step.output`, `step.risk`) directly into HTML strings. A crafted import JSON or typed label like `<img src=x onerror=alert(1)>` executes.
+
+**Fix:** Render container elements with `createElement`, then set text with `textContent` rather than building HTML strings. Example for `hydrateBlock`:
+
+```js
+function hydrateBlock(block) {
+  // ... setup ...
+  const card = document.createElement("div");
+  card.className = "canvas-card";
+
+  const h4 = document.createElement("h4");
+  h4.className = "node-label";
+  h4.textContent = title;          // safe — no HTML parsing
+
+  const pOwner = document.createElement("p");
+  pOwner.innerHTML = "<strong>Owner:</strong> ";
+  const ownerSpan = document.createElement("span");
+  ownerSpan.className = "node-person";
+  ownerSpan.textContent = defaults.person;
+  pOwner.appendChild(ownerSpan);
+
+  // ... repeat for other fields ...
+  card.append(h4, pOwner, ...);
+  block.appendChild(card);
+}
+```
+
+Apply the same pattern to `buildStarterFlowImport` or sanitize all string fields with a helper before interpolation.
+
+### 7. `innerHTML +=` in `drawArrow` re-serializes the entire canvas
+**File:** `engine/flowy.js` lines 277–281  
+`canvas_div.innerHTML += '...'` serializes all existing DOM, concatenates a string, then re-parses everything. This destroys and recreates all existing nodes (event listeners lost, slow) and re-parses any unsafe content already in the DOM.
+
+**Fix:** Use `insertAdjacentHTML('beforeend', ...)` or create elements via `createElement`. This is the minimal-change fix:
+
+```js
+// Replace: canvas_div.innerHTML += '<div class="arrowblock">...'
+canvas_div.insertAdjacentHTML('beforeend', '<div class="arrowblock">...');
+```
+
+---
+
+## Reliability improvements
+
+### 8. Silent error swallowing hides broken state
+**File:** `demo/main.js` lines 286–287, 362–363  
+Both `restore()` and the JSON import handler have empty `catch` blocks. Corrupt localStorage or an invalid JSON file fails invisibly.
+
+```js
+// Fix: at minimum log, ideally show user feedback
+} catch (err) {
+  console.error("Failed to restore workflow:", err);
+  // Optional: show a non-blocking error banner in the UI
+}
+```
+
+### 9. No cleanup/destroy for event listeners
+**File:** `engine/flowy.js` lines 617–628  
+All listeners are attached to `document` with no removal path. Calling `flowy()` a second time or navigating away in a SPA context accumulates duplicate listeners.
+
+**Fix:** Return a `destroy` function from `flowy.load()` that removes all registered listeners:
+
+```js
+function cleanup() {
+  document.removeEventListener("mousedown", flowy.beginDrag);
+  document.removeEventListener("mousedown", touchblock);
+  // ... etc
+}
+flowy.destroy = cleanup;
+```
+
+---
+
+## Performance improvements
+
+### 10. Debounce the properties form input handler
+**File:** `demo/main.js` line 290  
+Every keystroke calls `refreshAnalytics()` which calls `flowy.output()` and iterates all DOM blocks. Add a 150ms debounce.
+
+```js
+let analyticsTimer;
+form.addEventListener("input", (e) => {
+  if (!selectedBlock || !e.target.name) return;
+  const value = e.target.type === "checkbox" ? String(e.target.checked) : e.target.value;
+  setField(selectedBlock, e.target.name, value);
+  if (e.target.name === "risk" && e.target.value === "high") {
+    setField(selectedBlock, "approval", "true");
+    form.elements.namedItem("approval").checked = true;
+  }
+  updateNodeCard(selectedBlock);
+  clearTimeout(analyticsTimer);
+  analyticsTimer = setTimeout(refreshAnalytics, 150);
+});
+```
+
+### 11. Cache repeated `blocks.filter()` lookups
+**File:** `engine/flowy.js` — multiple functions  
+`snap()`, `checkOffset()`, and `rearrangeMe()` call `blocks.filter(a => a.id == id)[0]` 4–8 times per block with the same id. Cache the result once per loop iteration.
+
+---
+
+## Dead code to remove
+
+- `engine/flowy.js` lines 647–659: `addEventListenerMulti` and `removeEventListenerMulti` are defined but never called anywhere.
+- `engine/flowy.js` lines 301, 568: `var maxheight = 0` declared in `snap()` and `rearrangeMe()` but never read or updated.
+
+---
+
+## Suggested fix order
+
+| # | Fix | Risk | Effort |
+|---|-----|------|--------|
+| 1 | `r_array[0].y` in rearrangeMe | High impact, low risk | Small |
+| 2 | Bottom-edge scrollTop typo | High impact, trivial | Trivial |
+| 3 | localStorage clear on empty canvas | Medium impact, low risk | Trivial |
+| 4 | XSS via innerHTML interpolation | Security, medium effort | Medium |
+| 5 | Analytics label→ID matching | Correctness, low risk | Small |
+| 6 | `innerHTML +=` → `insertAdjacentHTML` | Perf + security | Small |
+| 7 | Silent catch blocks | Reliability | Trivial |
+| 8 | Form input debounce | Perf | Small |
+| 9 | Int/string type mismatch in snap | Correctness | Trivial |
+| 10 | Destroy/cleanup method | Reliability | Medium |
+| 11 | Remove dead code | Cleanliness | Trivial |

--- a/demo/flowy.min.js
+++ b/demo/flowy.min.js
@@ -1,1 +1,680 @@
-var flowy=function(e,t,l,i,n,o,r){t||(t=function(){}),l||(l=function(){}),i||(i=function(){return!0}),n||(n=function(){return!1}),o||(o=20),r||(r=80),Element.prototype.matches||(Element.prototype.matches=Element.prototype.msMatchesSelector||Element.prototype.webkitMatchesSelector),Element.prototype.closest||(Element.prototype.closest=function(e){var t=this;do{if(Element.prototype.matches.call(t,e))return t;t=t.parentElement||t.parentNode}while(null!==t&&1===t.nodeType);return null});var d=!1;function c(e,t,l){return i(e,t,l)}function a(e,t){return n(e,t)}flowy.load=function(){if(!d){d=!0;var i=[],n=[],s=e,u=0,p=0;"absolute"!=window.getComputedStyle(s).position&&"fixed"!=window.getComputedStyle(s).position||(u=s.getBoundingClientRect().left,p=s.getBoundingClientRect().top);var g,w,f,h,y,C,v=!1,m=o,B=r,x=0,R=!1,S=!1,b=0,L=document.createElement("DIV");L.classList.add("indicator"),L.classList.add("invisible"),s.appendChild(L),flowy.import=function(e){s.innerHTML=e.html;for(var t=0;t<e.blockarr.length;t++)i.push({childwidth:parseFloat(e.blockarr[t].childwidth),parent:parseFloat(e.blockarr[t].parent),id:parseFloat(e.blockarr[t].id),x:parseFloat(e.blockarr[t].x),y:parseFloat(e.blockarr[t].y),width:parseFloat(e.blockarr[t].width),height:parseFloat(e.blockarr[t].height)});i.length>1&&(D(),E())},flowy.output=function(){var e={html:s.innerHTML,blockarr:i,blocks:[]};if(i.length>0){for(var t=0;t<i.length;t++){e.blocks.push({id:i[t].id,parent:i[t].parent,data:[],attr:[]});var l=document.querySelector(".blockid[value='"+i[t].id+"']").parentNode;l.querySelectorAll("input").forEach(function(l){var i=l.getAttribute("name"),n=l.value;e.blocks[t].data.push({name:i,value:n})}),Array.prototype.slice.call(l.attributes).forEach(function(l){var i={};i[l.name]=l.value,e.blocks[t].attr.push(i)})}return e}},flowy.deleteBlocks=function(){i=[],s.innerHTML="<div class='indicator invisible'></div>"},flowy.beginDrag=function(e){if("absolute"!=window.getComputedStyle(s).position&&"fixed"!=window.getComputedStyle(s).position||(u=s.getBoundingClientRect().left,p=s.getBoundingClientRect().top),e.targetTouches?(y=e.changedTouches[0].clientX,C=e.changedTouches[0].clientY):(y=e.clientX,C=e.clientY),3!=e.which&&e.target.closest(".create-flowy")){h=e.target.closest(".create-flowy");var l=e.target.closest(".create-flowy").cloneNode(!0);e.target.closest(".create-flowy").classList.add("dragnow"),l.classList.add("block"),l.classList.remove("create-flowy"),0===i.length?(l.innerHTML+="<input type='hidden' name='blockid' class='blockid' value='"+i.length+"'>",document.body.appendChild(l),g=document.querySelector(".blockid[value='"+i.length+"']").parentNode):(l.innerHTML+="<input type='hidden' name='blockid' class='blockid' value='"+(Math.max.apply(Math,i.map(e=>e.id))+1)+"'>",document.body.appendChild(l),g=document.querySelector(".blockid[value='"+(parseInt(Math.max.apply(Math,i.map(e=>e.id)))+1)+"']").parentNode),n=e.target.closest(".create-flowy"),t(n),g.classList.add("dragging"),v=!0,w=y-e.target.closest(".create-flowy").getBoundingClientRect().left,f=C-e.target.closest(".create-flowy").getBoundingClientRect().top,g.style.left=y-w+"px",g.style.top=C-f+"px"}var n},flowy.endDrag=function(e){if(3!=e.which&&(v||R))if(S=!1,l(),document.querySelector(".indicator").classList.contains("invisible")||document.querySelector(".indicator").classList.add("invisible"),v&&(h.classList.remove("dragnow"),g.classList.remove("dragging")),0===parseInt(g.querySelector(".blockid").value)&&R)X("rearrange");else if(v&&0==i.length&&g.getBoundingClientRect().top+window.scrollY>s.getBoundingClientRect().top+window.scrollY&&g.getBoundingClientRect().left+window.scrollX>s.getBoundingClientRect().left+window.scrollX)X("drop");else if(v&&0==i.length)q();else if(v)for(var t=i.map(e=>e.id),o=0;o<i.length;o++){if(k(t[o])){v=!1,c(g,!1,document.querySelector(".blockid[value='"+t[o]+"']").parentNode)?T(g,o,t):(v=!1,q());break}o==i.length-1&&(v=!1,q())}else if(R)for(t=i.map(e=>e.id),o=0;o<i.length;o++){if(k(t[o])){v=!1,g.classList.remove("dragging"),T(g,o,t);break}if(o==i.length-1){if(a(g,i.filter(e=>e.id==t[o])[0])){v=!1,g.classList.remove("dragging"),T(g,t.indexOf(b),t);break}R=!1,n=[],v=!1,q();break}}},flowy.moveBlock=function(e){if(e.targetTouches?(y=e.targetTouches[0].clientX,C=e.targetTouches[0].clientY):(y=e.clientX,C=e.clientY),S){R=!0,g.classList.add("dragging");var t=parseInt(g.querySelector(".blockid").value);b=i.filter(e=>e.id==t)[0].parent,n.push(i.filter(e=>e.id==t)[0]),i=i.filter(function(e){return e.id!=t}),0!=t&&document.querySelector(".arrowid[value='"+t+"']").parentNode.remove();for(var l=i.filter(e=>e.parent==t),o=!1,r=[],d=[];!o;){for(var c=0;c<l.length;c++)if(l[c]!=t){n.push(i.filter(e=>e.id==l[c].id)[0]);const e=document.querySelector(".blockid[value='"+l[c].id+"']").parentNode,t=document.querySelector(".arrowid[value='"+l[c].id+"']").parentNode;e.style.left=e.getBoundingClientRect().left+window.scrollX-(g.getBoundingClientRect().left+window.scrollX)+"px",e.style.top=e.getBoundingClientRect().top+window.scrollY-(g.getBoundingClientRect().top+window.scrollY)+"px",t.style.left=t.getBoundingClientRect().left+window.scrollX-(g.getBoundingClientRect().left+window.scrollX)+"px",t.style.top=t.getBoundingClientRect().top+window.scrollY-(g.getBoundingClientRect().top+window.scrollY)+"px",g.appendChild(e),g.appendChild(t),r.push(l[c].id),d.push(l[c].id)}0==r.length?o=!0:(l=i.filter(e=>r.includes(e.parent)),r=[])}for(c=0;c<i.filter(e=>e.parent==t).length;c++){var a=i.filter(e=>e.parent==t)[c];i=i.filter(function(e){return e.id!=a})}for(c=0;c<d.length;c++){a=d[c];i=i.filter(function(e){return e.id!=a})}i.length>1&&D(),S=!1}if(v?(g.style.left=y-w+"px",g.style.top=C-f+"px"):R&&(g.style.left=y-w-(window.scrollX+u)+s.scrollLeft+"px",g.style.top=C-f-(window.scrollY+p)+s.scrollTop+"px",n.filter(e=>e.id==parseInt(g.querySelector(".blockid").value)).x=g.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(g).width)/2+s.scrollLeft,n.filter(e=>e.id==parseInt(g.querySelector(".blockid").value)).y=g.getBoundingClientRect().top+window.scrollY+parseInt(window.getComputedStyle(g).height)/2+s.scrollTop),v||R){y>s.getBoundingClientRect().width+s.getBoundingClientRect().left-10&&y<s.getBoundingClientRect().width+s.getBoundingClientRect().left+10?s.scrollLeft+=10:y<s.getBoundingClientRect().left+10&&y>s.getBoundingClientRect().left-10?s.scrollLeft-=10:C>s.getBoundingClientRect().height+s.getBoundingClientRect().top-10&&C<s.getBoundingClientRect().height+s.getBoundingClientRect().top+10?s.scrollTop+=10:C<s.getBoundingClientRect().top+10&&C>s.getBoundingClientRect().top-10&&(s.scrollLeft-=10);g.getBoundingClientRect().left,window.scrollX,parseInt(window.getComputedStyle(g).width),s.scrollLeft,s.getBoundingClientRect().left,g.getBoundingClientRect().top,window.scrollY,s.scrollTop,s.getBoundingClientRect().top;var h=i.map(e=>e.id);for(c=0;c<i.length;c++){if(k(h[c])){document.querySelector(".blockid[value='"+h[c]+"']").parentNode.appendChild(document.querySelector(".indicator")),document.querySelector(".indicator").style.left=document.querySelector(".blockid[value='"+h[c]+"']").parentNode.offsetWidth/2-5+"px",document.querySelector(".indicator").style.top=document.querySelector(".blockid[value='"+h[c]+"']").parentNode.offsetHeight+"px",document.querySelector(".indicator").classList.remove("invisible");break}c==i.length-1&&(document.querySelector(".indicator").classList.contains("invisible")||document.querySelector(".indicator").classList.add("invisible"))}}},document.addEventListener("mousedown",flowy.beginDrag),document.addEventListener("mousedown",Y,!1),document.addEventListener("touchstart",flowy.beginDrag),document.addEventListener("touchstart",Y,!1),document.addEventListener("mouseup",Y,!1),document.addEventListener("mousemove",flowy.moveBlock,!1),document.addEventListener("touchmove",flowy.moveBlock,!1),document.addEventListener("mouseup",flowy.endDrag,!1),document.addEventListener("touchend",flowy.endDrag,!1)}function k(e){const t=g.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(g).width)/2+s.scrollLeft-s.getBoundingClientRect().left,l=g.getBoundingClientRect().top+window.scrollY+s.scrollTop-s.getBoundingClientRect().top;return t>=i.filter(t=>t.id==e)[0].x-i.filter(t=>t.id==e)[0].width/2-m&&t<=i.filter(t=>t.id==e)[0].x+i.filter(t=>t.id==e)[0].width/2+m&&l>=i.filter(t=>t.id==e)[0].y-i.filter(t=>t.id==e)[0].height/2&&l<=i.filter(t=>t.id==e)[0].y+i.filter(t=>t.id==e)[0].height}function q(){s.appendChild(document.querySelector(".indicator")),g.parentNode.removeChild(g)}function X(e){if("drop"==e)c(g,!0,void 0),v=!1,g.style.top=g.getBoundingClientRect().top+window.scrollY-(p+window.scrollY)+s.scrollTop+"px",g.style.left=g.getBoundingClientRect().left+window.scrollX-(u+window.scrollX)+s.scrollLeft+"px",s.appendChild(g),i.push({parent:-1,childwidth:0,id:parseInt(g.querySelector(".blockid").value),x:g.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(g).width)/2+s.scrollLeft-s.getBoundingClientRect().left,y:g.getBoundingClientRect().top+window.scrollY+parseInt(window.getComputedStyle(g).height)/2+s.scrollTop-s.getBoundingClientRect().top,width:parseInt(window.getComputedStyle(g).width),height:parseInt(window.getComputedStyle(g).height)});else if("rearrange"==e){g.classList.remove("dragging"),R=!1;for(var t=0;t<n.length;t++)if(n[t].id!=parseInt(g.querySelector(".blockid").value)){const e=document.querySelector(".blockid[value='"+n[t].id+"']").parentNode,l=document.querySelector(".arrowid[value='"+n[t].id+"']").parentNode;e.style.left=e.getBoundingClientRect().left+window.scrollX-window.scrollX+s.scrollLeft-1-u+"px",e.style.top=e.getBoundingClientRect().top+window.scrollY-window.scrollY+s.scrollTop-p-1+"px",l.style.left=l.getBoundingClientRect().left+window.scrollX-window.scrollX+s.scrollLeft-u-1+"px",l.style.top=l.getBoundingClientRect().top+window.scrollY+s.scrollTop-1-p+"px",s.appendChild(e),s.appendChild(l),n[t].x=e.getBoundingClientRect().left+window.scrollX+parseInt(e.offsetWidth)/2+s.scrollLeft-s.getBoundingClientRect().left-1,n[t].y=e.getBoundingClientRect().top+window.scrollY+parseInt(e.offsetHeight)/2+s.scrollTop-s.getBoundingClientRect().top-1}n.filter(e=>0==e.id)[0].x=g.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(g).width)/2+s.scrollLeft-s.getBoundingClientRect().left,n.filter(e=>0==e.id)[0].y=g.getBoundingClientRect().top+window.scrollY+parseInt(window.getComputedStyle(g).height)/2+s.scrollTop-s.getBoundingClientRect().top,i=i.concat(n),n=[]}}function I(e,t,l,n){t<0?(s.innerHTML+='<div class="arrowblock"><input type="hidden" class="arrowid" value="'+g.querySelector(".blockid").value+'"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M'+(i.filter(e=>e.id==n)[0].x-e.x+5)+" 0L"+(i.filter(e=>e.id==n)[0].x-e.x+5)+" "+B/2+"L5 "+B/2+"L5 "+l+'" stroke="#C5CCD0" stroke-width="2px"/><path d="M0 '+(l-5)+"H10L5 "+l+"L0 "+(l-5)+'Z" fill="#C5CCD0"/></svg></div>',document.querySelector('.arrowid[value="'+g.querySelector(".blockid").value+'"]').parentNode.style.left=e.x-5-(u+window.scrollX)+s.scrollLeft+s.getBoundingClientRect().left+"px"):(s.innerHTML+='<div class="arrowblock"><input type="hidden" class="arrowid" value="'+g.querySelector(".blockid").value+'"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0L20 '+B/2+"L"+t+" "+B/2+"L"+t+" "+l+'" stroke="#C5CCD0" stroke-width="2px"/><path d="M'+(t-5)+" "+(l-5)+"H"+(t+5)+"L"+t+" "+l+"L"+(t-5)+" "+(l-5)+'Z" fill="#C5CCD0"/></svg></div>',document.querySelector('.arrowid[value="'+parseInt(g.querySelector(".blockid").value)+'"]').parentNode.style.left=i.filter(e=>e.id==n)[0].x-20-(u+window.scrollX)+s.scrollLeft+s.getBoundingClientRect().left+"px"),document.querySelector('.arrowid[value="'+parseInt(g.querySelector(".blockid").value)+'"]').parentNode.style.top=i.filter(e=>e.id==n)[0].y+i.filter(e=>e.id==n)[0].height/2+s.getBoundingClientRect().top-p+"px"}function N(e,t,l,n){t<0?(document.querySelector('.arrowid[value="'+n.id+'"]').parentNode.style.left=e.x-5-(u+window.scrollX)+s.getBoundingClientRect().left+"px",document.querySelector('.arrowid[value="'+n.id+'"]').parentNode.innerHTML='<input type="hidden" class="arrowid" value="'+n.id+'"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M'+(i.filter(e=>e.id==n.parent)[0].x-e.x+5)+" 0L"+(i.filter(e=>e.id==n.parent)[0].x-e.x+5)+" "+B/2+"L5 "+B/2+"L5 "+l+'" stroke="#C5CCD0" stroke-width="2px"/><path d="M0 '+(l-5)+"H10L5 "+l+"L0 "+(l-5)+'Z" fill="#C5CCD0"/></svg>'):(document.querySelector('.arrowid[value="'+n.id+'"]').parentNode.style.left=i.filter(e=>e.id==n.parent)[0].x-20-(u+window.scrollX)+s.getBoundingClientRect().left+"px",document.querySelector('.arrowid[value="'+n.id+'"]').parentNode.innerHTML='<input type="hidden" class="arrowid" value="'+n.id+'"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0L20 '+B/2+"L"+t+" "+B/2+"L"+t+" "+l+'" stroke="#C5CCD0" stroke-width="2px"/><path d="M'+(t-5)+" "+(l-5)+"H"+(t+5)+"L"+t+" "+l+"L"+(t-5)+" "+(l-5)+'Z" fill="#C5CCD0"/></svg>')}function T(e,t,l){R||s.appendChild(e);for(var o=0,r=0,d=0;d<i.filter(e=>e.parent==l[t]).length;d++){(f=i.filter(e=>e.parent==l[t])[d]).childwidth>f.width?o+=f.childwidth+m:o+=f.width+m}o+=parseInt(window.getComputedStyle(e).width);for(d=0;d<i.filter(e=>e.parent==l[t]).length;d++){(f=i.filter(e=>e.parent==l[t])[d]).childwidth>f.width?(document.querySelector(".blockid[value='"+f.id+"']").parentNode.style.left=i.filter(e=>e.id==l[t])[0].x-o/2+r+f.childwidth/2-f.width/2+"px",f.x=i.filter(e=>e.parent==l[t])[0].x-o/2+r+f.childwidth/2,r+=f.childwidth+m):(document.querySelector(".blockid[value='"+f.id+"']").parentNode.style.left=i.filter(e=>e.id==l[t])[0].x-o/2+r+"px",f.x=i.filter(e=>e.parent==l[t])[0].x-o/2+r+f.width/2,r+=f.width+m)}if(e.style.left=i.filter(e=>e.id==l[t])[0].x-o/2+r-(window.scrollX+u)+s.scrollLeft+s.getBoundingClientRect().left+"px",e.style.top=i.filter(e=>e.id==l[t])[0].y+i.filter(e=>e.id==l[t])[0].height/2+B-(window.scrollY+p)+s.getBoundingClientRect().top+"px",R){n.filter(t=>t.id==parseInt(e.querySelector(".blockid").value))[0].x=e.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(e).width)/2+s.scrollLeft-s.getBoundingClientRect().left,n.filter(t=>t.id==parseInt(e.querySelector(".blockid").value))[0].y=e.getBoundingClientRect().top+window.scrollY+parseInt(window.getComputedStyle(e).height)/2+s.scrollTop-s.getBoundingClientRect().top,n.filter(t=>t.id==e.querySelector(".blockid").value)[0].parent=l[t];for(d=0;d<n.length;d++)if(n[d].id!=parseInt(e.querySelector(".blockid").value)){const e=document.querySelector(".blockid[value='"+n[d].id+"']").parentNode,t=document.querySelector(".arrowid[value='"+n[d].id+"']").parentNode;e.style.left=e.getBoundingClientRect().left+window.scrollX-(window.scrollX+s.getBoundingClientRect().left)+s.scrollLeft+"px",e.style.top=e.getBoundingClientRect().top+window.scrollY-(window.scrollY+s.getBoundingClientRect().top)+s.scrollTop+"px",t.style.left=t.getBoundingClientRect().left+window.scrollX-(window.scrollX+s.getBoundingClientRect().left)+s.scrollLeft+20+"px",t.style.top=t.getBoundingClientRect().top+window.scrollY-(window.scrollY+s.getBoundingClientRect().top)+s.scrollTop+"px",s.appendChild(e),s.appendChild(t),n[d].x=e.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(e).width)/2+s.scrollLeft-s.getBoundingClientRect().left,n[d].y=e.getBoundingClientRect().top+window.scrollY+parseInt(window.getComputedStyle(e).height)/2+s.scrollTop-s.getBoundingClientRect().top}i=i.concat(n),n=[]}else i.push({childwidth:0,parent:l[t],id:parseInt(e.querySelector(".blockid").value),x:e.getBoundingClientRect().left+window.scrollX+parseInt(window.getComputedStyle(e).width)/2+s.scrollLeft-s.getBoundingClientRect().left,y:e.getBoundingClientRect().top+window.scrollY+parseInt(window.getComputedStyle(e).height)/2+s.scrollTop-s.getBoundingClientRect().top,width:parseInt(window.getComputedStyle(e).width),height:parseInt(window.getComputedStyle(e).height)});var c=i.filter(t=>t.id==parseInt(e.querySelector(".blockid").value))[0];if(I(c,c.x-i.filter(e=>e.id==l[t])[0].x+20,B,l[t]),-1!=i.filter(e=>e.id==l[t])[0].parent){for(var a=!1,g=l[t];!a;)if(-1==i.filter(e=>e.id==g)[0].parent)a=!0;else{var w=0;for(d=0;d<i.filter(e=>e.parent==g).length;d++){var f;(f=i.filter(e=>e.parent==g)[d]).childwidth>f.width?d==i.filter(e=>e.parent==g).length-1?w+=f.childwidth:w+=f.childwidth+m:d==i.filter(e=>e.parent==g).length-1?w+=f.width:w+=f.width+m}i.filter(e=>e.id==g)[0].childwidth=w,g=i.filter(e=>e.id==g)[0].parent}i.filter(e=>e.id==g)[0].childwidth=o}R&&(R=!1,e.classList.remove("dragging")),D(),E()}function Y(e){if(S=!1,M(e.target,"block")){var t=e.target.closest(".block");e.targetTouches?(y=e.targetTouches[0].clientX,C=e.targetTouches[0].clientY):(y=e.clientX,C=e.clientY),"mouseup"!==e.type&&M(e.target,"block")&&3!=e.which&&(v||R||(S=!0,w=y-((g=t).getBoundingClientRect().left+window.scrollX),f=C-(g.getBoundingClientRect().top+window.scrollY)))}}function M(e,t){return!!(e.className&&e.className.split(" ").indexOf(t)>=0)||e.parentNode&&M(e.parentNode,t)}function E(){x=i.map(e=>e.x);var e=i.map(e=>e.width),t=x.map(function(t,l){return t-e[l]/2});if((x=Math.min.apply(Math,t))<s.getBoundingClientRect().left+window.scrollX-u){for(var l=i.map(e=>e.id),n=0;n<i.length;n++)if(document.querySelector(".blockid[value='"+i.filter(e=>e.id==l[n])[0].id+"']").parentNode.style.left=i.filter(e=>e.id==l[n])[0].x-i.filter(e=>e.id==l[n])[0].width/2-x+s.getBoundingClientRect().left-u+20+"px",-1!=i.filter(e=>e.id==l[n])[0].parent){var o=i.filter(e=>e.id==l[n])[0],r=o.x-i.filter(e=>e.id==i.filter(e=>e.id==l[n])[0].parent)[0].x;document.querySelector('.arrowid[value="'+l[n]+'"]').parentNode.style.left=r<0?o.x-x+20-5+s.getBoundingClientRect().left-u+"px":i.filter(e=>e.id==i.filter(e=>e.id==l[n])[0].parent)[0].x-20-x+s.getBoundingClientRect().left-u+20+"px"}for(n=0;n<i.length;n++)i[n].x=document.querySelector(".blockid[value='"+i[n].id+"']").parentNode.getBoundingClientRect().left+window.scrollX+s.scrollLeft+parseInt(window.getComputedStyle(document.querySelector(".blockid[value='"+i[n].id+"']").parentNode).width)/2-20-s.getBoundingClientRect().left}}function D(){for(var e=i.map(e=>e.parent),t=0;t<e.length;t++){-1==e[t]&&t++;for(var l=0,n=0,o=0;o<i.filter(l=>l.parent==e[t]).length;o++){var r=i.filter(l=>l.parent==e[t])[o];0==i.filter(e=>e.parent==r.id).length&&(r.childwidth=0),r.childwidth>r.width?o==i.filter(l=>l.parent==e[t]).length-1?l+=r.childwidth:l+=r.childwidth+m:o==i.filter(l=>l.parent==e[t]).length-1?l+=r.width:l+=r.width+m}-1!=e[t]&&(i.filter(l=>l.id==e[t])[0].childwidth=l);for(o=0;o<i.filter(l=>l.parent==e[t]).length;o++){r=i.filter(l=>l.parent==e[t])[o];const c=document.querySelector(".blockid[value='"+r.id+"']").parentNode,a=i.filter(l=>l.id==e[t]);c.style.top=a.y+B+s.getBoundingClientRect().top-p+"px",a.y=a.y+B,r.childwidth>r.width?(c.style.left=a[0].x-l/2+n+r.childwidth/2-r.width/2-(u+window.scrollX)+s.getBoundingClientRect().left+"px",r.x=a[0].x-l/2+n+r.childwidth/2,n+=r.childwidth+m):(c.style.left=a[0].x-l/2+n-(u+window.scrollX)+s.getBoundingClientRect().left+"px",r.x=a[0].x-l/2+n+r.width/2,n+=r.width+m);var d=i.filter(e=>e.id==r.id)[0];N(d,d.x-i.filter(e=>e.id==r.parent)[0].x+20,B,r)}}}},flowy.load()};
+var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spacing_y) {
+    if (!grab) {
+        grab = function() {};
+    }
+    if (!release) {
+        release = function() {};
+    }
+    if (!snapping) {
+        snapping = function() {
+            return true;
+        }
+    }
+    if (!rearrange) {
+        rearrange = function() {
+            return false;
+        }
+    }
+    if (!spacing_x) {
+        spacing_x = 20;
+    }
+    if (!spacing_y) {
+        spacing_y = 80;
+    }
+    if (!Element.prototype.matches) {
+        Element.prototype.matches = Element.prototype.msMatchesSelector ||
+            Element.prototype.webkitMatchesSelector;
+    }
+    if (!Element.prototype.closest) {
+        Element.prototype.closest = function(s) {
+            var el = this;
+            do {
+                if (Element.prototype.matches.call(el, s)) return el;
+                el = el.parentElement || el.parentNode;
+            } while (el !== null && el.nodeType === 1);
+            return null;
+        };
+    }
+    var loaded = false;
+    flowy.load = function() {
+        if (!loaded)
+            loaded = true;
+        else
+            return;
+        var blocks = [];
+        var blockstemp = [];
+        var canvas_div = canvas;
+        var absx = 0;
+        var absy = 0;
+        if (window.getComputedStyle(canvas_div).position == "absolute" || window.getComputedStyle(canvas_div).position == "fixed") {
+            absx = canvas_div.getBoundingClientRect().left;
+            absy = canvas_div.getBoundingClientRect().top;
+        }
+        var active = false;
+        var zoom = 1;
+        var paddingx = spacing_x;
+        var paddingy = spacing_y;
+        var offsetleft = 0;
+        var rearrange = false;
+        var drag, dragx, dragy, original;
+        var mouse_x, mouse_y;
+        var dragblock = false;
+        var prevblock = 0;
+        var el = document.createElement("DIV");
+        el.classList.add('indicator');
+        el.classList.add('invisible');
+        canvas_div.appendChild(el);
+        flowy.setZoom = function(level) {
+            zoom = level;
+        }
+
+        function scaled(rect) {
+            return {
+                left: rect.left / zoom,
+                top: rect.top / zoom,
+                right: rect.right / zoom,
+                bottom: rect.bottom / zoom,
+                width: rect.width / zoom,
+                height: rect.height / zoom
+            };
+        }
+
+        flowy.import = function(output, skipRearrange) {
+            canvas_div.innerHTML = output.html;
+            for (var a = 0; a < output.blockarr.length; a++) {
+                blocks.push({
+                    childwidth: parseFloat(output.blockarr[a].childwidth),
+                    parent: parseFloat(output.blockarr[a].parent),
+                    id: parseFloat(output.blockarr[a].id),
+                    x: parseFloat(output.blockarr[a].x),
+                    y: parseFloat(output.blockarr[a].y),
+                    width: parseFloat(output.blockarr[a].width),
+                    height: parseFloat(output.blockarr[a].height)
+                })
+            }
+            if (!skipRearrange && blocks.length > 1) {
+                rearrangeMe();
+                checkOffset();
+            }
+        }
+        flowy.output = function() {
+            var html_ser = canvas_div.innerHTML;
+            var json_data = {
+                html: html_ser,
+                blockarr: blocks,
+                blocks: []
+            };
+            if (blocks.length > 0) {
+                for (var i = 0; i < blocks.length; i++) {
+                    json_data.blocks.push({
+                        id: blocks[i].id,
+                        parent: blocks[i].parent,
+                        data: [],
+                        attr: []
+                    });
+                    var blockParent = document.querySelector(".blockid[value='" + blocks[i].id + "']").parentNode;
+                    blockParent.querySelectorAll("input").forEach(function(block) {
+                        var json_name = block.getAttribute("name");
+                        var json_value = block.value;
+                        json_data.blocks[i].data.push({
+                            name: json_name,
+                            value: json_value
+                        });
+                    });
+                    Array.prototype.slice.call(blockParent.attributes).forEach(function(attribute) {
+                        var jsonobj = {};
+                        jsonobj[attribute.name] = attribute.value;
+                        json_data.blocks[i].attr.push(jsonobj);
+                    });
+                }
+                return json_data;
+            }
+        }
+        flowy.deleteBlocks = function() {
+            blocks = [];
+            canvas_div.innerHTML = "<div class='indicator invisible'></div>";
+        }
+
+        flowy.beginDrag = function(event) {
+            if (window.getComputedStyle(canvas_div).position == "absolute" || window.getComputedStyle(canvas_div).position == "fixed") {
+                absx = canvas_div.getBoundingClientRect().left;
+                absy = canvas_div.getBoundingClientRect().top;
+            }
+            if (event.targetTouches) {
+                mouse_x = event.changedTouches[0].clientX / zoom;
+                mouse_y = event.changedTouches[0].clientY / zoom;
+            } else {
+                mouse_x = event.clientX / zoom;
+                mouse_y = event.clientY / zoom;
+            }
+            if (event.which != 3 && event.target.closest(".create-flowy")) {
+                original = event.target.closest(".create-flowy");
+                var newNode = event.target.closest(".create-flowy").cloneNode(true);
+                event.target.closest(".create-flowy").classList.add("dragnow");
+                newNode.classList.add("block");
+                newNode.classList.remove("create-flowy");
+                if (blocks.length === 0) {
+                    newNode.innerHTML += "<input type='hidden' name='blockid' class='blockid' value='" + blocks.length + "'>";
+                    document.body.appendChild(newNode);
+                    drag = document.querySelector(".blockid[value='" + blocks.length + "']").parentNode;
+                } else {
+                    newNode.innerHTML += "<input type='hidden' name='blockid' class='blockid' value='" + (Math.max.apply(Math, blocks.map(a => a.id)) + 1) + "'>";
+                    document.body.appendChild(newNode);
+                    drag = document.querySelector(".blockid[value='" + (parseInt(Math.max.apply(Math, blocks.map(a => a.id))) + 1) + "']").parentNode;
+                }
+                blockGrabbed(event.target.closest(".create-flowy"));
+                drag.classList.add("dragging");
+                active = true;
+                dragx = mouse_x - (event.target.closest(".create-flowy").getBoundingClientRect().left);
+                dragy = mouse_y - (event.target.closest(".create-flowy").getBoundingClientRect().top);
+                drag.style.left = mouse_x - dragx + "px";
+                drag.style.top = mouse_y - dragy + "px";
+            }
+        }
+
+        flowy.endDrag = function(event) {
+            if (event.which != 3 && (active || rearrange)) {
+                dragblock = false;
+                blockReleased();
+                if (!document.querySelector(".indicator").classList.contains("invisible")) {
+                    document.querySelector(".indicator").classList.add("invisible");
+                }
+                if (active) {
+                    original.classList.remove("dragnow");
+                    drag.classList.remove("dragging");
+                }
+                if (parseInt(drag.querySelector(".blockid").value) === 0 && rearrange) {
+                    firstBlock("rearrange")    
+                } else if (active && blocks.length == 0 && (scaled(drag.getBoundingClientRect()).top + window.scrollY) > (canvas_div.getBoundingClientRect().top + window.scrollY) && (scaled(drag.getBoundingClientRect()).left + window.scrollX) > (canvas_div.getBoundingClientRect().left + window.scrollX)) {
+                    firstBlock("drop");
+                } else if (active && blocks.length == 0) {
+                    removeSelection();
+                } else if (active) {
+                    var blocko = blocks.map(a => a.id);
+                    for (var i = 0; i < blocks.length; i++) {
+                        if (checkAttach(blocko[i])) {
+                            active = false;
+                            if (blockSnap(drag, false, document.querySelector(".blockid[value='" + blocko[i] + "']").parentNode)) {
+                                snap(drag, i, blocko);
+                            } else {
+                                active = false;
+                                removeSelection();
+                            }
+                            break;
+                        } else if (i == blocks.length - 1) {
+                            active = false;
+                            removeSelection();
+                        }
+                    }
+                } else if (rearrange) {
+                    var blocko = blocks.map(a => a.id);
+                    for (var i = 0; i < blocks.length; i++) {
+                        if (checkAttach(blocko[i])) {
+                            active = false;
+                            drag.classList.remove("dragging");
+                            snap(drag, i, blocko);
+                            break;
+                        } else if (i == blocks.length - 1) {
+                            if (beforeDelete(drag, blocks.filter(id => id.id == blocko[i])[0])) {
+                                active = false;
+                                drag.classList.remove("dragging");
+                                snap(drag, blocko.indexOf(prevblock), blocko);
+                                break;
+                            } else {
+                                rearrange = false;
+                                blockstemp = [];
+                                active = false;
+                                removeSelection();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
+        function checkAttach(id) {
+            const xpos = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+            const ypos = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+            if (xpos >= blocks.filter(a => a.id == id)[0].x - (blocks.filter(a => a.id == id)[0].width / 2) - paddingx && xpos <= blocks.filter(a => a.id == id)[0].x + (blocks.filter(a => a.id == id)[0].width / 2) + paddingx && ypos >= blocks.filter(a => a.id == id)[0].y - (blocks.filter(a => a.id == id)[0].height / 2) && ypos <= blocks.filter(a => a.id == id)[0].y + blocks.filter(a => a.id == id)[0].height) {
+                return true;   
+            } else {
+                return false;
+            }
+        }
+        
+        function removeSelection() {
+            canvas_div.appendChild(document.querySelector(".indicator"));
+            drag.parentNode.removeChild(drag);
+        }
+        
+        function firstBlock(type) {
+            if (type == "drop") {
+                blockSnap(drag, true, undefined);
+                active = false;
+                drag.style.top = (scaled(drag.getBoundingClientRect()).top + window.scrollY) - (absy + window.scrollY) + canvas_div.scrollTop + "px";
+                drag.style.left = (scaled(drag.getBoundingClientRect()).left + window.scrollX) - (absx + window.scrollX) + canvas_div.scrollLeft + "px";
+                canvas_div.appendChild(drag);
+                blocks.push({
+                    parent: -1,
+                    childwidth: 0,
+                    id: parseInt(drag.querySelector(".blockid").value),
+                    x: (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left,
+                    y: (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top,
+                    width: parseInt(window.getComputedStyle(drag).width),
+                    height: parseInt(window.getComputedStyle(drag).height)
+                });
+            } else if (type == "rearrange") {
+                drag.classList.remove("dragging");
+                rearrange = false;
+                for (var w = 0; w < blockstemp.length; w++) {
+                    if (blockstemp[w].id != parseInt(drag.querySelector(".blockid").value)) {
+                        const blockParent = document.querySelector(".blockid[value='" + blockstemp[w].id + "']").parentNode;
+                        const arrowParent = document.querySelector(".arrowid[value='" + blockstemp[w].id + "']").parentNode;
+                        blockParent.style.left = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) - (window.scrollX) + canvas_div.scrollLeft - 1 - absx + "px";
+                        blockParent.style.top = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) - (window.scrollY) + canvas_div.scrollTop - absy - 1 + "px";
+                        arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (window.scrollX) + canvas_div.scrollLeft - absx - 1 + "px";
+                        arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) + canvas_div.scrollTop - 1 - absy + "px";
+                        canvas_div.appendChild(blockParent);
+                        canvas_div.appendChild(arrowParent);
+                        blockstemp[w].x = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) + (parseInt(blockParent.offsetWidth) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left - 1;
+                        blockstemp[w].y = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) + (parseInt(blockParent.offsetHeight) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top - 1;
+                    }
+                }
+                blockstemp.filter(a => a.id == 0)[0].x = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                blockstemp.filter(a => a.id == 0)[0].y = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                blocks = blocks.concat(blockstemp);
+                blockstemp = [];
+            }
+        }
+        
+        function drawArrow(arrow, x, y, id) {
+            const parentBlock = blocks.filter(a => a.id == id)[0];
+            if (x < 0) {
+                canvas_div.insertAdjacentHTML("beforeend", '<div class="arrowblock"><input type="hidden" class="arrowid" value="' + drag.querySelector(".blockid").value + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M' + (parentBlock.x - arrow.x + 5) + ' 0L' + (parentBlock.x - arrow.x + 5) + ' ' + (paddingy / 2) + 'L5 ' + (paddingy / 2) + 'L5 ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M0 ' + (y - 5) + 'H10L5 ' + y + 'L0 ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg></div>');
+                document.querySelector('.arrowid[value="' + drag.querySelector(".blockid").value + '"]').parentNode.style.left = (arrow.x - 5) - (absx + window.scrollX) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
+            } else {
+                canvas_div.insertAdjacentHTML("beforeend", '<div class="arrowblock"><input type="hidden" class="arrowid" value="' + drag.querySelector(".blockid").value + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0L20 ' + (paddingy / 2) + 'L' + (x) + ' ' + (paddingy / 2) + 'L' + x + ' ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M' + (x - 5) + ' ' + (y - 5) + 'H' + (x + 5) + 'L' + x + ' ' + y + 'L' + (x - 5) + ' ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg></div>');
+                document.querySelector('.arrowid[value="' + parseInt(drag.querySelector(".blockid").value) + '"]').parentNode.style.left = parentBlock.x - 20 - (absx + window.scrollX) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
+            }
+            document.querySelector('.arrowid[value="' + parseInt(drag.querySelector(".blockid").value) + '"]').parentNode.style.top = parentBlock.y + (parentBlock.height / 2) + canvas_div.getBoundingClientRect().top - absy + "px";
+        }
+        
+        function updateArrow(arrow, x, y, children) { 
+            if (x < 0) {
+                document.querySelector('.arrowid[value="' + children.id + '"]').parentNode.style.left = (arrow.x - 5) - (absx + window.scrollX) + canvas_div.getBoundingClientRect().left + "px";
+                document.querySelector('.arrowid[value="' + children.id + '"]').parentNode.innerHTML = '<input type="hidden" class="arrowid" value="' + children.id + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M' + (blocks.filter(id => id.id == children.parent)[0].x - arrow.x + 5) + ' 0L' + (blocks.filter(id => id.id == children.parent)[0].x - arrow.x + 5) + ' ' + (paddingy / 2) + 'L5 ' + (paddingy / 2) + 'L5 ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M0 ' + (y - 5) + 'H10L5 ' + y + 'L0 ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg>';
+            } else {
+                document.querySelector('.arrowid[value="' + children.id + '"]').parentNode.style.left = blocks.filter(id => id.id == children.parent)[0].x - 20 - (absx + window.scrollX) + canvas_div.getBoundingClientRect().left + "px";
+                document.querySelector('.arrowid[value="' + children.id + '"]').parentNode.innerHTML = '<input type="hidden" class="arrowid" value="' + children.id + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0L20 ' + (paddingy / 2) + 'L' + (x) + ' ' + (paddingy / 2) + 'L' + x + ' ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M' + (x - 5) + ' ' + (y - 5) + 'H' + (x + 5) + 'L' + x + ' ' + y + 'L' + (x - 5) + ' ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg>';
+            }
+        }
+
+        function snap(drag, i, blocko) {
+            if (!rearrange) {
+                canvas_div.appendChild(drag);
+            }
+            const parentId = blocko[i];
+            const parentBlock = blocks.filter(id => id.id == parentId)[0];
+            const parentChildren = blocks.filter(id => id.parent == parentId);
+            var totalwidth = 0;
+            var totalremove = 0;
+            for (var w = 0; w < parentChildren.length; w++) {
+                var children = parentChildren[w];
+                if (children.childwidth > children.width) {
+                    totalwidth += children.childwidth + paddingx;
+                } else {
+                    totalwidth += children.width + paddingx;
+                }
+            }
+            totalwidth += parseInt(window.getComputedStyle(drag).width);
+            for (var w = 0; w < parentChildren.length; w++) {
+                var children = parentChildren[w];
+                if (children.childwidth > children.width) {
+                    document.querySelector(".blockid[value='" + children.id + "']").parentNode.style.left = parentBlock.x - (totalwidth / 2) + totalremove + (children.childwidth / 2) - (children.width / 2) + "px";
+                    children.x = parentBlock.x - (totalwidth / 2) + totalremove + (children.childwidth / 2);
+                    totalremove += children.childwidth + paddingx;
+                } else {
+                    document.querySelector(".blockid[value='" + children.id + "']").parentNode.style.left = parentBlock.x - (totalwidth / 2) + totalremove + "px";
+                    children.x = parentBlock.x - (totalwidth / 2) + totalremove + (children.width / 2);
+                    totalremove += children.width + paddingx;
+                }
+            }
+            drag.style.left = parentBlock.x - (totalwidth / 2) + totalremove - (window.scrollX + absx) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
+            drag.style.top = parentBlock.y + (parentBlock.height / 2) + paddingy - (window.scrollY + absy) + canvas_div.getBoundingClientRect().top + "px";
+            if (rearrange) {
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].x = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].y = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                blockstemp.filter(a => a.id === parseInt(drag.querySelector(".blockid").value))[0].parent = blocko[i];
+                for (var w = 0; w < blockstemp.length; w++) {
+                    if (blockstemp[w].id != parseInt(drag.querySelector(".blockid").value)) {
+                        const blockParent = document.querySelector(".blockid[value='" + blockstemp[w].id + "']").parentNode;
+                        const arrowParent = document.querySelector(".arrowid[value='" + blockstemp[w].id + "']").parentNode;
+                        blockParent.style.left = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) - (window.scrollX + canvas_div.getBoundingClientRect().left) + canvas_div.scrollLeft + "px";
+                        blockParent.style.top = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) - (window.scrollY + canvas_div.getBoundingClientRect().top) + canvas_div.scrollTop + "px";
+                        arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (window.scrollX + canvas_div.getBoundingClientRect().left) + canvas_div.scrollLeft + 20 + "px";
+                        arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) - (window.scrollY + canvas_div.getBoundingClientRect().top) + canvas_div.scrollTop + "px";
+                        canvas_div.appendChild(blockParent);
+                        canvas_div.appendChild(arrowParent);
+
+                        blockstemp[w].x = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(blockParent).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                        blockstemp[w].y = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(blockParent).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                    }
+                }
+                blocks = blocks.concat(blockstemp);
+                blockstemp = [];
+            } else {
+                blocks.push({
+                    childwidth: 0,
+                    parent: blocko[i],
+                    id: parseInt(drag.querySelector(".blockid").value),
+                    x: (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left,
+                    y: (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top,
+                    width: parseInt(window.getComputedStyle(drag).width),
+                    height: parseInt(window.getComputedStyle(drag).height)
+                });
+            }
+            
+            var arrowblock = blocks.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0];
+            var arrowx = arrowblock.x - parentBlock.x + 20;
+            var arrowy = paddingy;
+            drawArrow(arrowblock, arrowx, arrowy, parentId);
+            
+            if (parentBlock.parent != -1) {
+                var flag = false;
+                var idval = blocko[i];
+                while (!flag) {
+                    if (blocks.filter(a => a.id == idval)[0].parent == -1) {
+                        flag = true;
+                    } else {
+                        var zwidth = 0;
+                        for (var w = 0; w < blocks.filter(id => id.parent == idval).length; w++) {
+                            var children = blocks.filter(id => id.parent == idval)[w];
+                            if (children.childwidth > children.width) {
+                                if (w == blocks.filter(id => id.parent == idval).length - 1) {
+                                    zwidth += children.childwidth;
+                                } else {
+                                    zwidth += children.childwidth + paddingx;
+                                }
+                            } else {
+                                if (w == blocks.filter(id => id.parent == idval).length - 1) {
+                                    zwidth += children.width;
+                                } else {
+                                    zwidth += children.width + paddingx;
+                                }
+                            }
+                        }
+                        blocks.filter(a => a.id == idval)[0].childwidth = zwidth;
+                        idval = blocks.filter(a => a.id == idval)[0].parent;
+                    }
+                }
+                blocks.filter(id => id.id == idval)[0].childwidth = totalwidth;
+            }
+            if (rearrange) {
+                rearrange = false;
+                drag.classList.remove("dragging");
+            }
+            rearrangeMe();
+            checkOffset();
+        }
+
+        function touchblock(event) {
+            dragblock = false;
+            if (hasParentClass(event.target, "block")) {
+                var theblock = event.target.closest(".block");
+                if (event.targetTouches) {
+                    mouse_x = event.targetTouches[0].clientX / zoom;
+                    mouse_y = event.targetTouches[0].clientY / zoom;
+                } else {
+                    mouse_x = event.clientX / zoom;
+                    mouse_y = event.clientY / zoom;
+                }
+                if (event.type !== "mouseup" && hasParentClass(event.target, "block")) {
+                    if (event.which != 3) {
+                        if (!active && !rearrange) {
+                            dragblock = true;
+                            drag = theblock;
+                            dragx = mouse_x - (scaled(drag.getBoundingClientRect()).left + window.scrollX);
+                            dragy = mouse_y - (scaled(drag.getBoundingClientRect()).top + window.scrollY);
+                        }
+                    }
+                }
+            }
+        }
+
+        function hasParentClass(element, classname) {
+            if (element.className) {
+                if (element.className.split(' ').indexOf(classname) >= 0) return true;
+            }
+            return element.parentNode && hasParentClass(element.parentNode, classname);
+        }
+
+        flowy.moveBlock = function(event) {
+            if (event.targetTouches) {
+                mouse_x = event.targetTouches[0].clientX / zoom;
+                mouse_y = event.targetTouches[0].clientY / zoom;
+            } else {
+                mouse_x = event.clientX / zoom;
+                mouse_y = event.clientY / zoom;
+            }
+            if (dragblock) {
+                rearrange = true;
+                drag.classList.add("dragging");
+                var blockid = parseInt(drag.querySelector(".blockid").value);
+                prevblock = blocks.filter(a => a.id == blockid)[0].parent;
+                blockstemp.push(blocks.filter(a => a.id == blockid)[0]);
+                blocks = blocks.filter(function(e) {
+                    return e.id != blockid
+                });
+                if (blockid != 0) {
+                    document.querySelector(".arrowid[value='" + blockid + "']").parentNode.remove();
+                }
+                var layer = blocks.filter(a => a.parent == blockid);
+                var flag = false;
+                var foundids = [];
+                var allids = [];
+                while (!flag) {
+                    for (var i = 0; i < layer.length; i++) {
+                        if (layer[i] != blockid) {
+                            blockstemp.push(blocks.filter(a => a.id == layer[i].id)[0]);
+                            const blockParent = document.querySelector(".blockid[value='" + layer[i].id + "']").parentNode;
+                            const arrowParent = document.querySelector(".arrowid[value='" + layer[i].id + "']").parentNode;
+                            blockParent.style.left = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) - (scaled(drag.getBoundingClientRect()).left + window.scrollX) + "px";
+                            blockParent.style.top = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) - (scaled(drag.getBoundingClientRect()).top + window.scrollY) + "px";
+                            arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (scaled(drag.getBoundingClientRect()).left + window.scrollX) + "px";
+                            arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) - (scaled(drag.getBoundingClientRect()).top + window.scrollY) + "px";
+                            drag.appendChild(blockParent);
+                            drag.appendChild(arrowParent);
+                            foundids.push(layer[i].id);
+                            allids.push(layer[i].id);
+                        }
+                    }
+                    if (foundids.length == 0) {
+                        flag = true;
+                    } else {
+                        layer = blocks.filter(a => foundids.includes(a.parent));
+                        foundids = [];
+                    }
+                }
+                for (var i = 0; i < blocks.filter(a => a.parent == blockid).length; i++) {
+                    var blocknumber = blocks.filter(a => a.parent == blockid)[i];
+                    blocks = blocks.filter(function(e) {
+                        return e.id != blocknumber
+                    });
+                }
+                for (var i = 0; i < allids.length; i++) {
+                    var blocknumber = allids[i];
+                    blocks = blocks.filter(function(e) {
+                        return e.id != blocknumber
+                    });
+                }
+                if (blocks.length > 1) {
+                    rearrangeMe();
+                }
+                dragblock = false;
+            }
+            if (active) {
+                drag.style.left = mouse_x - dragx + "px";
+                drag.style.top = mouse_y - dragy + "px";
+            } else if (rearrange) {
+                drag.style.left = mouse_x - dragx - (window.scrollX + absx) + canvas_div.scrollLeft + "px";
+                drag.style.top = mouse_y - dragy - (window.scrollY + absy) + canvas_div.scrollTop + "px";
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value)).x = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft;
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value)).y = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop;
+            }
+            if (active || rearrange) {
+                if (mouse_x > canvas_div.getBoundingClientRect().width + canvas_div.getBoundingClientRect().left - 10 && mouse_x < canvas_div.getBoundingClientRect().width + canvas_div.getBoundingClientRect().left + 10) {
+                    canvas_div.scrollLeft += 10;
+                } else if (mouse_x < canvas_div.getBoundingClientRect().left + 10 && mouse_x > canvas_div.getBoundingClientRect().left - 10) {
+                    canvas_div.scrollLeft -= 10;
+                } else if (mouse_y > canvas_div.getBoundingClientRect().height + canvas_div.getBoundingClientRect().top - 10 && mouse_y < canvas_div.getBoundingClientRect().height + canvas_div.getBoundingClientRect().top + 10) {
+                    canvas_div.scrollTop += 10;
+                } else if (mouse_y < canvas_div.getBoundingClientRect().top + 10 && mouse_y > canvas_div.getBoundingClientRect().top - 10) {
+                    canvas_div.scrollTop -= 10;
+                }
+                var xpos = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                var ypos = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                var blocko = blocks.map(a => a.id);
+                for (var i = 0; i < blocks.length; i++) {
+                    if (checkAttach(blocko[i])) {
+                        document.querySelector(".blockid[value='" + blocko[i] + "']").parentNode.appendChild(document.querySelector(".indicator"));
+                        document.querySelector(".indicator").style.left = (document.querySelector(".blockid[value='" + blocko[i] + "']").parentNode.offsetWidth / 2) - 5 + "px";
+                        document.querySelector(".indicator").style.top = document.querySelector(".blockid[value='" + blocko[i] + "']").parentNode.offsetHeight + "px";
+                        document.querySelector(".indicator").classList.remove("invisible");
+                        break;
+                    } else if (i == blocks.length - 1) {
+                        if (!document.querySelector(".indicator").classList.contains("invisible")) {
+                            document.querySelector(".indicator").classList.add("invisible");
+                        }
+                    }
+                }
+            }
+        }
+
+        function checkOffset() {
+            offsetleft = blocks.map(a => a.x);
+            var widths = blocks.map(a => a.width);
+            var mathmin = offsetleft.map(function(item, index) {
+                return item - (widths[index] / 2);
+            })
+            offsetleft = Math.min.apply(Math, mathmin);
+            if (offsetleft < (canvas_div.getBoundingClientRect().left + window.scrollX - absx)) {
+                var blocko = blocks.map(a => a.id);
+                for (var w = 0; w < blocks.length; w++) {
+                    const block = blocks.filter(a => a.id == blocko[w])[0];
+                    document.querySelector(".blockid[value='" + block.id + "']").parentNode.style.left = block.x - (block.width / 2) - offsetleft + canvas_div.getBoundingClientRect().left - absx + 20 + "px";
+                    if (block.parent != -1) {
+                        var arrowblock = block;
+                        var parent = blocks.filter(a => a.id == block.parent)[0];
+                        var arrowx = arrowblock.x - parent.x;
+                        if (arrowx < 0) {
+                            document.querySelector('.arrowid[value="' + blocko[w] + '"]').parentNode.style.left = (arrowblock.x - offsetleft + 20 - 5) + canvas_div.getBoundingClientRect().left - absx + "px";
+                        } else {
+                            document.querySelector('.arrowid[value="' + blocko[w] + '"]').parentNode.style.left = parent.x - 20 - offsetleft + canvas_div.getBoundingClientRect().left - absx + 20 + "px";
+                        }
+                    }
+                }
+                for (var w = 0; w < blocks.length; w++) {
+                    blocks[w].x = (document.querySelector(".blockid[value='" + blocks[w].id + "']").parentNode.getBoundingClientRect().left + window.scrollX) + (canvas_div.scrollLeft) + (parseInt(window.getComputedStyle(document.querySelector(".blockid[value='" + blocks[w].id + "']").parentNode).width) / 2) - 20 - canvas_div.getBoundingClientRect().left;
+                }
+            }
+        }
+
+        function rearrangeMe() {
+            var result = blocks.map(a => a.parent);
+            for (var z = 0; z < result.length; z++) {
+                if (result[z] == -1) {
+                    z++;
+                }
+                var totalwidth = 0;
+                var totalremove = 0;
+                const currentParent = result[z];
+                const childrenByParent = blocks.filter(id => id.parent == currentParent);
+                for (var w = 0; w < childrenByParent.length; w++) {
+                    var children = childrenByParent[w];
+                    if (blocks.filter(id => id.parent == children.id).length == 0) {
+                        children.childwidth = 0;
+                    }
+                    if (children.childwidth > children.width) {
+                        if (w == childrenByParent.length - 1) {
+                            totalwidth += children.childwidth;
+                        } else {
+                            totalwidth += children.childwidth + paddingx;
+                        }
+                    } else {
+                        if (w == childrenByParent.length - 1) {
+                            totalwidth += children.width;
+                        } else {
+                            totalwidth += children.width + paddingx;
+                        }
+                    }
+                }
+                if (currentParent != -1) {
+                    blocks.filter(a => a.id == currentParent)[0].childwidth = totalwidth;
+                }
+                for (var w = 0; w < childrenByParent.length; w++) {
+                    var children = childrenByParent[w];
+                    const r_block = document.querySelector(".blockid[value='" + children.id + "']").parentNode;
+                    const r_array = blocks.filter(id => id.id == currentParent);
+                    r_block.style.top = r_array[0].y + paddingy + canvas_div.getBoundingClientRect().top - absy + "px";
+                    r_array[0].y = r_array[0].y + paddingy;
+                    if (children.childwidth > children.width) {
+                        r_block.style.left = r_array[0].x - (totalwidth / 2) + totalremove + (children.childwidth / 2) - (children.width / 2) - (absx + window.scrollX) + canvas_div.getBoundingClientRect().left + "px";
+                        children.x = r_array[0].x - (totalwidth / 2) + totalremove + (children.childwidth / 2);
+                        totalremove += children.childwidth + paddingx;
+                    } else {
+                        r_block.style.left = r_array[0].x - (totalwidth / 2) + totalremove - (absx + window.scrollX) + canvas_div.getBoundingClientRect().left + "px";
+                        children.x = r_array[0].x - (totalwidth / 2) + totalremove + (children.width / 2);
+                        totalremove += children.width + paddingx;
+                    }
+
+                    var arrowblock = blocks.filter(a => a.id == children.id)[0];
+                    var arrowx = arrowblock.x - blocks.filter(a => a.id == children.parent)[0].x + 20;
+                    var arrowy = paddingy;
+                    updateArrow(arrowblock, arrowx, arrowy, children);
+                }
+            }
+        }
+        
+        document.addEventListener("mousedown", flowy.beginDrag);
+        document.addEventListener("mousedown", touchblock, false);
+        document.addEventListener("touchstart", flowy.beginDrag);
+        document.addEventListener("touchstart", touchblock, false);
+        document.addEventListener("mouseup", touchblock, false);
+        document.addEventListener("mousemove", flowy.moveBlock, false);
+        document.addEventListener("touchmove", flowy.moveBlock, false);
+        document.addEventListener("mouseup", flowy.endDrag, false);
+        document.addEventListener("touchend", flowy.endDrag, false);
+
+        flowy.destroy = function() {
+            document.removeEventListener("mousedown", flowy.beginDrag);
+            document.removeEventListener("mousedown", touchblock, false);
+            document.removeEventListener("touchstart", flowy.beginDrag);
+            document.removeEventListener("touchstart", touchblock, false);
+            document.removeEventListener("mouseup", touchblock, false);
+            document.removeEventListener("mousemove", flowy.moveBlock, false);
+            document.removeEventListener("touchmove", flowy.moveBlock, false);
+            document.removeEventListener("mouseup", flowy.endDrag, false);
+            document.removeEventListener("touchend", flowy.endDrag, false);
+            loaded = false;
+        };
+    }
+
+    function blockGrabbed(block) {
+        grab(block);
+    }
+
+    function blockReleased() {
+        release();
+    }
+
+    function blockSnap(drag, first, parent) {
+        return snapping(drag, first, parent);
+    }
+
+    function beforeDelete(drag, parent) {
+        return rearrange(drag, parent);
+    }
+
+    flowy.load();
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,164 +1,87 @@
- <!DOCTYPE html>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <!-- Primary Meta Tags -->
-<title>Flowy - The simple flowchart engine</title>
-<meta name="title" content="Flowy - The simple flowchart engine">
-<meta name="description" content="Flowy is a minimal javascript library to create flowcharts. Use it for automation software, mind mapping tools, programming platforms, and more. Made by Alyssa X.">
-
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website">
-<meta property="og:url" content="https://alyssax.com/x/flowy">
-<meta property="og:title" content="Flowy - The simple flowchart engine">
-<meta property="og:description" content="Flowy is a minimal javascript library to create flowcharts. Use it for automation software, mind mapping tools, programming platforms, and more. Made by Alyssa X.">
-<meta property="og:image" content="https://alyssax.com/x/assets/meta.png">
-
-<!-- Twitter -->
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="https://alyssax.com/x/flowy">
-<meta property="twitter:site" content="alyssaxuu">
-<meta property="twitter:title" content="Flowy - The simple flowchart engine">
-<meta property="twitter:description" content="Flowy is a minimal javascript library to create flowcharts. Use it for automation software, mind mapping tools, programming platforms, and more. Made by Alyssa X.">
-<meta property="twitter:image" content="https://alyssax.com/x/assets/meta.png">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" rel="stylesheet">
-    <link href='styles.css' rel='stylesheet' type='text/css'>
-    <link href='flowy.min.css' rel='stylesheet' type='text/css'>
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <script src="flowy.min.js"></script>
-    <script src="main.js"></script>   
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PMM Agentic Workflow Designer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="flowy.min.css" rel="stylesheet" type="text/css">
+  <link href="styles.css" rel="stylesheet" type="text/css">
+  <script src="flowy.min.js"></script>
+  <script src="main.js" defer></script>
 </head>
 <body>
-    <div id="navigation">
-        <div id="leftside">
-            <div id="details">
-            <div id="back"><img src="assets/arrow.svg"></div>
-            <div id="names">
-                <p id="title">Your automation pipeline</p>
-                <p id="subtitle">Marketing automation</p>
-            </div>
-        </div>            
-        </div>
-        <div id="centerswitch">
-            <div id="leftswitch">Diagram view</div>
-            <div id="rightswitch">Code editor</div>
-        </div>
-        <div id="buttonsright">
-            <div id="discard">Discard</div>
-            <div id="publish">Publish to site</div>
-        </div>
+  <header class="topbar">
+    <div>
+      <h1>PMM Agentic Workflow Designer</h1>
+      <p>Flowy-based offline workflow mapping for people, tools, load, risk, and automation potential</p>
     </div>
-    <div id="leftcard">
-        <div id="closecard">
-            <img src="assets/closeleft.svg">
-        </div>
-        <p id="header">Blocks</p>
-        <div id="search">
-            <img src="assets/search.svg">
-            <input type="text" placeholder="Search blocks">
-        </div>
-        <div id="subnav">
-            <div id="triggers" class="navactive side">Triggers</div>
-            <div id="actions" class="navdisabled side">Actions</div>
-            <div id="loggers" class="navdisabled side">Loggers</div>
-        </div>
-        <div id="blocklist">
-            <div class="blockelem create-flowy noselect">
-                <input type="hidden" name='blockelemtype' class="blockelemtype" value="1">
-                <div class="grabme">
-                    <img src="assets/grabme.svg">
-                </div>
-                <div class="blockin">
-                    <div class="blockico">
-                        <span></span>
-                        <img src="assets/eye.svg">
-                    </div>
-                    <div class="blocktext">
-                        <p class="blocktitle">New visitor</p>
-                        <p class="blockdesc">Triggers when somebody visits a specified page</p>
-                    </div>
-                </div>
-            </div>
-            <div class="blockelem create-flowy noselect">
-                <input type="hidden" name='blockelemtype' class="blockelemtype" value="2">
-                <div class="grabme">
-                    <img src="assets/grabme.svg">
-                </div>
-                <div class="blockin">
-                    <div class="blockico">
-                        <span></span>
-                        <img src="assets/action.svg">
-                    </div>
-                    <div class="blocktext">
-                        <p class="blocktitle">Action is performed</p>
-                        <p class="blockdesc">Triggers when somebody performs a specified action</p>
-                    </div>
-                </div>
-            </div>
-            <div class="blockelem create-flowy noselect">
-                <input type="hidden" name='blockelemtype' class="blockelemtype" value="3">
-                <div class="grabme">
-                    <img src="assets/grabme.svg">
-                </div>
-                <div class="blockin">
-                    <div class="blockico">
-                        <span></span>
-                        <img src="assets/time.svg">
-                    </div>
-                    <div class="blocktext">
-                        <p class="blocktitle">Time has passed</p>
-                        <p class="blockdesc">Triggers after a specified amount of time</p>
-                    </div>
-                </div>
-            </div>
-            <div class="blockelem create-flowy noselect">
-                <input type="hidden" name='blockelemtype' class="blockelemtype" value="4">
-                <div class="grabme">
-                    <img src="assets/grabme.svg">
-                </div>
-                <div class="blockin">
-                    <div class="blockico">
-                        <span></span>
-                        <img src="assets/error.svg">
-                    </div>
-                    <div class="blocktext">
-                        <p class="blocktitle">Error prompt</p>
-                        <p class="blockdesc">Triggers when a specified error happens</p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div id="footer">
-            <a href="https://github.com/alyssaxuu/flowy/" target="_blank">GitHub</a>
-            <span>·</span>
-            <a href="https://twitter.com/alyssaxuu/status/1199724989353730048" target="_blank">Twitter</a>
-            <span>·</span>
-                <a href="https://alyssax.com" target="_blank"><p>Made with</p><img src="assets/heart.svg"><p>by</p> Alyssa X</a>
-        </div>
+    <div class="actions">
+      <button id="load-template">Load PMM Templates</button>
+      <button id="build-starter">Build Starter Flow</button>
+      <button id="save-local">Save Local</button>
+      <button id="export-json">Export JSON</button>
+      <label class="file-button">
+        Import JSON
+        <input id="import-json" type="file" accept="application/json">
+      </label>
+      <button id="clear-canvas" class="danger">Clear Canvas</button>
     </div>
-    <div id="propwrap">
-        <div id="properties">
-            <div id="close">
-                <img src="assets/close.svg">
-            </div>
-            <p id="header2">Properties</p>
-            <div id="propswitch">
-                <div id="dataprop">Data</div>
-                <div id="alertprop">Alerts</div>
-                <div id="logsprop">Logs</div>
-            </div>
-            <div id="proplist">
-                <p class="inputlabel">Select database</p>
-                <div class="dropme">Database 1 <img src="assets/dropdown.svg"></div>
-                <p class="inputlabel">Check properties</p>
-                <div class="dropme">All<img src="assets/dropdown.svg"></div>
-                <div class="checkus"><img src="assets/checkon.svg"><p>Log on successful performance</p></div>
-                <div class="checkus"><img src="assets/checkoff.svg"><p>Give priority to this block</p></div>
-            </div>
-            <div id="divisionthing"></div>
-            <div id="removeblock">Delete blocks</div>
-        </div>
-    </div>
-    <div id="canvas">
-    </div>
+  </header>
+
+  <main class="layout">
+    <aside class="sidebar">
+      <div class="panel">
+        <h2>Template Blocks</h2>
+        <input id="search-blocks" type="text" placeholder="Search templates">
+        <div id="blocklist" class="blocklist"></div>
+      </div>
+    </aside>
+
+    <section id="canvas-wrap">
+      <div id="canvas"></div>
+    </section>
+
+    <aside class="rightbar">
+      <div class="panel">
+        <h2>Step Properties</h2>
+        <form id="properties-form">
+          <label>Workflow Step<input name="label" required></label>
+          <label>Person / Role<input name="person" placeholder="PMM Manager"></label>
+          <label>Tool<input name="tool" placeholder="Notion, HubSpot"></label>
+          <label>Input<input name="input" placeholder="Brief, data pull"></label>
+          <label>Output<input name="output" placeholder="Draft, localized asset"></label>
+          <label>Data Source / DB<input name="datasource" placeholder="CRM, Product analytics"></label>
+          <label>Hours per Run<input name="loadHours" type="number" min="0" step="0.25" value="1"></label>
+          <label>Frequency per Week<input name="frequency" type="number" min="0" step="1" value="5"></label>
+          <label>Automation Potential (%)<input name="automation" type="number" min="0" max="100" value="40"></label>
+          <label>Automation Confidence (%)<input name="confidence" type="number" min="0" max="100" value="80"></label>
+          <label>Data Quality (%)<input name="dataQuality" type="number" min="0" max="100" value="85"></label>
+          <label>Risk Profile
+            <select name="risk">
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </label>
+          <label>Execution Bucket
+            <select name="bucket">
+              <option value="human">Human-led</option>
+              <option value="assist">AI-assisted</option>
+              <option value="agent">Agent-executable</option>
+            </select>
+          </label>
+          <label class="check-row"><input name="approval" type="checkbox">Requires human approval gate</label>
+        </form>
+      </div>
+
+      <div class="panel">
+        <h2>Workday Analytics</h2>
+        <div id="analytics"></div>
+      </div>
+    </aside>
+  </main>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,12 @@
 
     <section id="canvas-wrap">
       <div id="canvas"></div>
+      <div id="zoom-controls">
+        <button id="zoom-out" title="Zoom out">−</button>
+        <span id="zoom-label">100%</span>
+        <button id="zoom-in" title="Zoom in">+</button>
+        <button id="zoom-reset" title="Reset zoom">⊡</button>
+      </div>
     </section>
 
     <aside class="rightbar">

--- a/demo/main.js
+++ b/demo/main.js
@@ -149,6 +149,36 @@ document.addEventListener("DOMContentLoaded", () => {
 
   flowy(canvas, () => {}, () => {}, snap, () => true, 30, 90);
 
+  let zoomLevel = 1.0;
+  const ZOOM_STEP = 0.25;
+  const ZOOM_MIN = 0.25;
+  const ZOOM_MAX = 2.0;
+
+  function applyZoom(level) {
+    zoomLevel = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level));
+    canvas.style.transform = `scale(${zoomLevel})`;
+    canvas.style.transformOrigin = "0 0";
+    canvas.style.width = `${100 / zoomLevel}%`;
+    canvas.style.height = `${100 / zoomLevel}%`;
+    document.getElementById("zoom-label").textContent = `${Math.round(zoomLevel * 100)}%`;
+    document.getElementById("zoom-out").disabled = zoomLevel <= ZOOM_MIN;
+    document.getElementById("zoom-in").disabled = zoomLevel >= ZOOM_MAX;
+    flowy.setZoom(zoomLevel);
+  }
+
+  document.getElementById("zoom-in").addEventListener("click", () => applyZoom(zoomLevel + ZOOM_STEP));
+  document.getElementById("zoom-out").addEventListener("click", () => applyZoom(zoomLevel - ZOOM_STEP));
+  document.getElementById("zoom-reset").addEventListener("click", () => applyZoom(1.0));
+
+  document.getElementById("canvas-wrap").addEventListener("wheel", (e) => {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      applyZoom(zoomLevel + (e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP));
+    }
+  }, { passive: false });
+
+  applyZoom(1.0);
+
   function getFlowBlocks() {
     const output = flowy.output();
     const result = [];

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,107 +1,539 @@
-document.addEventListener("DOMContentLoaded", function(){
-    var rightcard = false;
-    var tempblock;
-    var tempblock2;
-    document.getElementById("blocklist").innerHTML = '<div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="1"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/eye.svg"></div><div class="blocktext">                        <p class="blocktitle">New visitor</p><p class="blockdesc">Triggers when somebody visits a specified page</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="2"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                    <div class="blockico"><span></span><img src="assets/action.svg"></div><div class="blocktext">                        <p class="blocktitle">Action is performed</p><p class="blockdesc">Triggers when somebody performs a specified action</p></div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="3"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                    <div class="blockico"><span></span><img src="assets/time.svg"></div><div class="blocktext">                        <p class="blocktitle">Time has passed</p><p class="blockdesc">Triggers after a specified amount of time</p>          </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="4"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                    <div class="blockico"><span></span><img src="assets/error.svg"></div><div class="blocktext">                        <p class="blocktitle">Error prompt</p><p class="blockdesc">Triggers when a specified error happens</p>              </div></div></div>';
-    flowy(document.getElementById("canvas"), drag, release, snapping);
-    function addEventListenerMulti(type, listener, capture, selector) {
-        var nodes = document.querySelectorAll(selector);
-        for (var i = 0; i < nodes.length; i++) {
-            nodes[i].addEventListener(type, listener, capture);
-        }
+document.addEventListener("DOMContentLoaded", () => {
+  const STORAGE_KEY = "pmm_flowy_designer_v1";
+  const blockList = document.getElementById("blocklist");
+  const search = document.getElementById("search-blocks");
+  const canvas = document.getElementById("canvas");
+  const form = document.getElementById("properties-form");
+  const analytics = document.getElementById("analytics");
+  let selectedBlock = null;
+  let analyticsTimer;
+
+  const templates = [
+    { type: "1", title: "Market Insight Intake", desc: "Collect product, customer, and market signal inputs", tag: "Standardized" },
+    { type: "2", title: "Message Framework Draft", desc: "Build positioning narrative and proof points", tag: "Standardized" },
+    { type: "3", title: "Sales Enablement Pack", desc: "Create pitch assets and objection handling", tag: "Standardized" },
+    { type: "4", title: "Owned Channel Orchestration", desc: "Coordinate website, email, community, and lifecycle", tag: "Owned Channels" },
+    { type: "5", title: "Localization Planning", desc: "Locale scope, region owner, and cultural checks", tag: "Localization UI+Content" },
+    { type: "6", title: "Localization Asset Production", desc: "Localized copy, screenshots, and launch kit", tag: "Localization UI+Content" },
+    { type: "7", title: "Performance Review Loop", desc: "Measure outcome, workload, and next iteration", tag: "Standardized" }
+  ];
+
+  const defaults = {
+    label: "New Step",
+    person: "PMM Manager",
+    tool: "Notion",
+    input: "Brief",
+    output: "Draft",
+    datasource: "CRM",
+    loadHours: "1",
+    frequency: "5",
+    automation: "40",
+    confidence: "80",
+    dataQuality: "85",
+    risk: "medium",
+    bucket: "assist",
+    approval: "false"
+  };
+
+  function riskFactor(risk) {
+    if (risk === "low") return 1;
+    if (risk === "high") return 0.5;
+    return 0.75;
+  }
+
+  function renderTemplates(filter = "") {
+    const q = filter.trim().toLowerCase();
+    const html = templates
+      .filter((t) => [t.title, t.desc, t.tag].join(" ").toLowerCase().includes(q))
+      .map((t) => `
+        <div class="blockelem create-flowy noselect" data-title="${t.title}" data-desc="${t.desc}">
+          <input type="hidden" name="blockelemtype" class="blockelemtype" value="${t.type}">
+          <div class="blockin">
+            <p class="blocktitle">${t.title}</p>
+            <p class="blockdesc">${t.desc}</p>
+            <div class="blocktag">${t.tag}</div>
+          </div>
+        </div>
+      `)
+      .join("");
+    blockList.innerHTML = html;
+  }
+
+  function getField(block, name) {
+    const el = block.querySelector(`input[name="${name}"]`);
+    return el ? el.value : "";
+  }
+
+  function setField(block, name, value) {
+    let el = block.querySelector(`input[name="${name}"]`);
+    if (!el) {
+      el = document.createElement("input");
+      el.type = "hidden";
+      el.name = name;
+      block.appendChild(el);
     }
-    function snapping(drag, first) {
-        var grab = drag.querySelector(".grabme");
-        grab.parentNode.removeChild(grab);
-        var blockin = drag.querySelector(".blockin");
-        blockin.parentNode.removeChild(blockin);
-        if (drag.querySelector(".blockelemtype").value == "1") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/eyeblue.svg'><p class='blockyname'>New visitor</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>When a <span>new visitor</span> goes to <span>Site 1</span></div>";
-        } else if (drag.querySelector(".blockelemtype").value == "2") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/actionblue.svg'><p class='blockyname'>Action is performed</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>When <span>Action 1</span> is performed</div>";
-        } else if (drag.querySelector(".blockelemtype").value == "3") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/timeblue.svg'><p class='blockyname'>Time has passed</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>When <span>10 seconds</span> have passed</div>";
-        } else if (drag.querySelector(".blockelemtype").value == "4") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/errorblue.svg'><p class='blockyname'>Error prompt</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>When <span>Error 1</span> is triggered</div>";
-        } else if (drag.querySelector(".blockelemtype").value == "5") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/databaseorange.svg'><p class='blockyname'>New database entry</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Add <span>Data object</span> to <span>Database 1</span></div>";
-        } else if (drag.querySelector(".blockelemtype").value == "6") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/databaseorange.svg'><p class='blockyname'>Update database</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Update <span>Database 1</span></div>";
-        } else if (drag.querySelector(".blockelemtype").value == "7") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/actionorange.svg'><p class='blockyname'>Perform an action</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Perform <span>Action 1</span></div>";
-        } else if (drag.querySelector(".blockelemtype").value == "8") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/twitterorange.svg'><p class='blockyname'>Make a tweet</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Tweet <span>Query 1</span> with the account <span>@alyssaxuu</span></div>";
-        } else if (drag.querySelector(".blockelemtype").value == "9") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/logred.svg'><p class='blockyname'>Add new log entry</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Add new <span>success</span> log entry</div>";
-        } else if (drag.querySelector(".blockelemtype").value == "10") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/logred.svg'><p class='blockyname'>Update logs</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Edit <span>Log Entry 1</span></div>";
-        } else if (drag.querySelector(".blockelemtype").value == "11") {
-            drag.innerHTML += "<div class='blockyleft'><img src='assets/errorred.svg'><p class='blockyname'>Prompt an error</p></div><div class='blockyright'><img src='assets/more.svg'></div><div class='blockydiv'></div><div class='blockyinfo'>Trigger <span>Error 1</span></div>";
-        }
-        return true;
+    el.value = value;
+  }
+
+  function hydrateBlock(block) {
+    const title = block.dataset.title || defaults.label;
+    const desc = block.dataset.desc || "Workflow step";
+    const old = block.querySelector(".blockin");
+    if (old) old.remove();
+    const grab = block.querySelector(".grabme");
+    if (grab) grab.remove();
+
+    const card = document.createElement("div");
+    card.className = "canvas-card";
+    const h4 = document.createElement("h4");
+    h4.className = "node-label";
+    h4.textContent = title;
+
+    const pOwner = document.createElement("p");
+    pOwner.innerHTML = "<strong>Owner:</strong> ";
+    const ownerSpan = document.createElement("span");
+    ownerSpan.className = "node-person";
+    ownerSpan.textContent = defaults.person;
+    pOwner.appendChild(ownerSpan);
+
+    const pTool = document.createElement("p");
+    pTool.innerHTML = "<strong>Tool:</strong> ";
+    const toolSpan = document.createElement("span");
+    toolSpan.className = "node-tool";
+    toolSpan.textContent = defaults.tool;
+    pTool.appendChild(toolSpan);
+
+    const pOutput = document.createElement("p");
+    pOutput.innerHTML = "<strong>Output:</strong> ";
+    const outputSpan = document.createElement("span");
+    outputSpan.className = "node-output";
+    outputSpan.textContent = defaults.output;
+    pOutput.appendChild(outputSpan);
+
+    const pRisk = document.createElement("p");
+    pRisk.innerHTML = "<strong>Risk:</strong> ";
+    const riskSpan = document.createElement("span");
+    riskSpan.className = "node-risk";
+    riskSpan.textContent = defaults.risk;
+    pRisk.appendChild(riskSpan);
+    pRisk.append(" | ");
+    const strongAuto = document.createElement("strong");
+    strongAuto.textContent = "Auto:";
+    pRisk.appendChild(strongAuto);
+    pRisk.append(" ");
+    const autoSpan = document.createElement("span");
+    autoSpan.className = "node-automation";
+    autoSpan.textContent = `${defaults.automation}%`;
+    pRisk.appendChild(autoSpan);
+
+    card.append(h4, pOwner, pTool, pOutput, pRisk);
+    block.appendChild(card);
+
+    const meta = { ...defaults, label: title, output: desc };
+    Object.entries(meta).forEach(([k, v]) => setField(block, k, v));
+  }
+
+  function updateNodeCard(block) {
+    block.querySelector(".node-label").textContent = getField(block, "label");
+    block.querySelector(".node-person").textContent = getField(block, "person");
+    block.querySelector(".node-tool").textContent = getField(block, "tool");
+    block.querySelector(".node-output").textContent = getField(block, "output");
+    block.querySelector(".node-risk").textContent = getField(block, "risk");
+    block.querySelector(".node-automation").textContent = `${getField(block, "automation")}%`;
+  }
+
+  function snap(block) {
+    hydrateBlock(block);
+    return true;
+  }
+
+  flowy(canvas, () => {}, () => {}, snap, () => true, 30, 90);
+
+  function getFlowBlocks() {
+    const output = flowy.output();
+    const result = [];
+    if (output && output.blocks) {
+      output.blocks.forEach((b) => {
+        const dataMap = {};
+        b.data.forEach((d) => {
+          dataMap[d.name] = d.value;
+        });
+        result.push({ ...b, dataMap });
+      });
     }
-    function drag(block) {
-        block.classList.add("blockdisabled");
-        tempblock2 = block;
+    return result;
+  }
+
+  function refreshAnalytics() {
+    const blocks = getFlowBlocks();
+    if (!blocks.length) {
+      analytics.innerHTML = "<div class='metric'>No workflow steps yet.</div>";
+      return;
     }
-    function release() {
-        if (tempblock2) {
-            tempblock2.classList.remove("blockdisabled");
-        }
-    }
-    var disabledClick = function(){
-        document.querySelector(".navactive").classList.add("navdisabled");
-        document.querySelector(".navactive").classList.remove("navactive");
-        this.classList.add("navactive");
-        this.classList.remove("navdisabled");
-        if (this.getAttribute("id") == "triggers") {
-            document.getElementById("blocklist").innerHTML = '<div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="1"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/eye.svg"></div><div class="blocktext">                        <p class="blocktitle">New visitor</p><p class="blockdesc">Triggers when somebody visits a specified page</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="2"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                    <div class="blockico"><span></span><img src="assets/action.svg"></div><div class="blocktext">                        <p class="blocktitle">Action is performed</p><p class="blockdesc">Triggers when somebody performs a specified action</p></div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="3"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                    <div class="blockico"><span></span><img src="assets/time.svg"></div><div class="blocktext">                        <p class="blocktitle">Time has passed</p><p class="blockdesc">Triggers after a specified amount of time</p>          </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="4"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                    <div class="blockico"><span></span><img src="assets/error.svg"></div><div class="blocktext">                        <p class="blocktitle">Error prompt</p><p class="blockdesc">Triggers when a specified error happens</p>              </div></div></div>';
-        } else if (this.getAttribute("id") == "actions") {
-            document.getElementById("blocklist").innerHTML = '<div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="5"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/database.svg"></div><div class="blocktext">                        <p class="blocktitle">New database entry</p><p class="blockdesc">Adds a new entry to a specified database</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="6"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/database.svg"></div><div class="blocktext">                        <p class="blocktitle">Update database</p><p class="blockdesc">Edits and deletes database entries and properties</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="7"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/action.svg"></div><div class="blocktext">                        <p class="blocktitle">Perform an action</p><p class="blockdesc">Performs or edits a specified action</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="8"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/twitter.svg"></div><div class="blocktext">                        <p class="blocktitle">Make a tweet</p><p class="blockdesc">Makes a tweet with a specified query</p>        </div></div></div>';
-        } else if (this.getAttribute("id") == "loggers") {
-            document.getElementById("blocklist").innerHTML = '<div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="9"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/log.svg"></div><div class="blocktext">                        <p class="blocktitle">Add new log entry</p><p class="blockdesc">Adds a new log entry to this project</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="10"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/log.svg"></div><div class="blocktext">                        <p class="blocktitle">Update logs</p><p class="blockdesc">Edits and deletes log entries in this project</p>        </div></div></div><div class="blockelem create-flowy noselect"><input type="hidden" name="blockelemtype" class="blockelemtype" value="11"><div class="grabme"><img src="assets/grabme.svg"></div><div class="blockin">                  <div class="blockico"><span></span><img src="assets/error.svg"></div><div class="blocktext">                        <p class="blocktitle">Prompt an error</p><p class="blockdesc">Triggers a specified error</p>        </div></div></div>';
-        }
-    }
-    addEventListenerMulti("click", disabledClick, false, ".side");
-    document.getElementById("close").addEventListener("click", function(){
-       if (rightcard) {
-           rightcard = false;
-           document.getElementById("properties").classList.remove("expanded");
-           setTimeout(function(){
-                document.getElementById("propwrap").classList.remove("itson"); 
-           }, 300);
-            tempblock.classList.remove("selectedblock");
-       } 
+
+    const byPerson = {};
+    let totalDailyHours = 0;
+    let agenticHours = 0;
+    let approvalGates = 0;
+    let violations = 0;
+
+    blocks.forEach((b) => {
+      const person = b.dataMap.person || "Unassigned";
+      const hours = Number(b.dataMap.loadHours || 0);
+      const perWeek = Number(b.dataMap.frequency || 0);
+      const automation = Number(b.dataMap.automation || 0) / 100;
+      const confidence = Number(b.dataMap.confidence || 0) / 100;
+      const dataQuality = Number(b.dataMap.dataQuality || 0) / 100;
+      const risk = b.dataMap.risk || "medium";
+      const daily = (hours * perWeek) / 5;
+      const requiresApproval = risk === "high";
+      if (requiresApproval && b.dataMap.approval !== "true") {
+        violations += 1;
+        b.dataMap.approval = "true";
+        document.querySelectorAll("#canvas .block").forEach((node) => {
+          if (parseInt(getField(node, "blockid")) === b.id) {
+            setField(node, "approval", "true");
+          }
+        });
+      }
+      const agentic = daily * automation * riskFactor(risk) * confidence * dataQuality;
+
+      totalDailyHours += daily;
+      agenticHours += agentic;
+      if (b.dataMap.approval === "true" || requiresApproval) approvalGates += 1;
+
+      byPerson[person] = (byPerson[person] || 0) + daily;
     });
-    
-document.getElementById("removeblock").addEventListener("click", function(){
- flowy.deleteBlocks();
-});
-var aclick = false;
-var noinfo = false;
-var beginTouch = function (event) {
-    aclick = true;
-    noinfo = false;
-    if (event.target.closest(".create-flowy")) {
-        noinfo = true;
+
+    const rows = Object.entries(byPerson)
+      .map(([name, daily]) => `<tr><td>${name}</td><td>${daily.toFixed(2)}h/day</td><td>${(daily / 8 * 100).toFixed(0)}%</td></tr>`)
+      .join("");
+
+    const automationPotential = totalDailyHours ? (agenticHours / totalDailyHours) * 100 : 0;
+    analytics.innerHTML = `
+      <div class="metric"><strong>Total Daily Load (8h model):</strong> ${totalDailyHours.toFixed(2)}h</div>
+      <div class="metric"><strong>Estimated 24/7 Agentic Capacity:</strong> ${agenticHours.toFixed(2)}h/day equivalent</div>
+      <div class="metric"><strong>Automation Potential:</strong> ${automationPotential.toFixed(1)}%</div>
+      <div class="metric"><strong>Approval Gates:</strong> ${approvalGates}</div>
+      <div class="metric"><strong>Risk Rule Violations Auto-corrected:</strong> ${violations}</div>
+      <table class="table">
+        <thead><tr><th>Person</th><th>Load</th><th>8h Utilization</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+  }
+
+  function buildStarterFlowImport(blocks) {
+    const width = 270;
+    const height = 130;
+    const rootX = 600;
+    const rootY = 160;
+    const gapX = 320;
+    const gapY = 220;
+    const blockarr = [];
+    const wrapper = document.createElement("div");
+    const indicator = document.createElement("div");
+    indicator.className = "indicator invisible";
+    wrapper.appendChild(indicator);
+
+    const nodeById = new Map();
+    const children = new Map();
+    blocks.forEach((b) => {
+      nodeById.set(b.id, b);
+      children.set(b.id, []);
+    });
+    blocks.forEach((b) => {
+      if (b.parent >= 0 && children.has(b.parent)) children.get(b.parent).push(b.id);
+    });
+
+    const subtreeWidth = new Map();
+    const computeSubtreeWidth = (id) => {
+      const childIds = children.get(id) || [];
+      if (!childIds.length) {
+        subtreeWidth.set(id, width);
+        return width;
+      }
+      const totalChildren = childIds.reduce((sum, childId) => sum + computeSubtreeWidth(childId), 0) + gapX * (childIds.length - 1);
+      const w = Math.max(width, totalChildren);
+      subtreeWidth.set(id, w);
+      return w;
+    };
+
+    const positioned = new Map();
+    const assignPosition = (id, x, y) => {
+      positioned.set(id, { x, y });
+      const childIds = children.get(id) || [];
+      if (!childIds.length) return;
+      const totalChildren = childIds.reduce((sum, childId) => sum + subtreeWidth.get(childId), 0) + gapX * (childIds.length - 1);
+      let cursor = x - totalChildren / 2;
+      childIds.forEach((childId) => {
+        const cw = subtreeWidth.get(childId);
+        const childX = cursor + cw / 2;
+        assignPosition(childId, childX, y + gapY);
+        cursor += cw + gapX;
+      });
+    };
+
+    const root = blocks.find((b) => b.parent === -1);
+    if (!root) return { html: wrapper.innerHTML, blockarr, blocks: [] };
+    computeSubtreeWidth(root.id);
+    assignPosition(root.id, rootX, rootY);
+
+    blocks.forEach((step) => {
+      const pos = positioned.get(step.id);
+      if (!pos) return;
+      blockarr.push({ childwidth: 0, parent: step.parent, id: step.id, x: pos.x, y: pos.y, width, height });
+
+      const block = document.createElement("div");
+      block.className = "block";
+      block.style.left = `${pos.x - width / 2}px`;
+      block.style.top = `${pos.y - height / 2}px`;
+
+      const fields = {
+        blockid: String(step.id),
+        id: String(step.id),
+        parent: String(step.parent),
+        label: step.label,
+        person: step.person,
+        tool: step.tool,
+        input: step.input || "Brief",
+        output: step.output,
+        datasource: step.datasource || "CRM",
+        loadHours: step.loadHours || "1",
+        frequency: step.frequency || "5",
+        automation: step.automation,
+        confidence: step.confidence,
+        dataQuality: step.dataQuality,
+        risk: step.risk,
+        bucket: step.bucket,
+        approval: step.approval
+      };
+      Object.entries(fields).forEach(([name, value]) => {
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = name;
+        if (name === "blockid") input.className = "blockid";
+        input.value = value;
+        block.appendChild(input);
+      });
+
+      const card = document.createElement("div");
+      card.className = "canvas-card";
+      const h4 = document.createElement("h4");
+      h4.className = "node-label";
+      h4.textContent = step.label;
+      card.appendChild(h4);
+      const owner = document.createElement("p");
+      owner.innerHTML = "<strong>Owner:</strong> ";
+      const ownerSpan = document.createElement("span");
+      ownerSpan.className = "node-person";
+      ownerSpan.textContent = step.person;
+      owner.appendChild(ownerSpan);
+      card.appendChild(owner);
+      const tool = document.createElement("p");
+      tool.innerHTML = "<strong>Tool:</strong> ";
+      const toolSpan = document.createElement("span");
+      toolSpan.className = "node-tool";
+      toolSpan.textContent = step.tool;
+      tool.appendChild(toolSpan);
+      card.appendChild(tool);
+      const output = document.createElement("p");
+      output.innerHTML = "<strong>Output:</strong> ";
+      const outputSpan = document.createElement("span");
+      outputSpan.className = "node-output";
+      outputSpan.textContent = step.output;
+      output.appendChild(outputSpan);
+      card.appendChild(output);
+      const risk = document.createElement("p");
+      risk.innerHTML = "<strong>Risk:</strong> ";
+      const riskSpan = document.createElement("span");
+      riskSpan.className = "node-risk";
+      riskSpan.textContent = step.risk;
+      risk.appendChild(riskSpan);
+      risk.append(" | ");
+      const autoStrong = document.createElement("strong");
+      autoStrong.textContent = "Auto:";
+      risk.appendChild(autoStrong);
+      risk.append(" ");
+      const autoSpan = document.createElement("span");
+      autoSpan.className = "node-automation";
+      autoSpan.textContent = `${step.automation}%`;
+      risk.appendChild(autoSpan);
+      card.appendChild(risk);
+      block.appendChild(card);
+      wrapper.appendChild(block);
+
+      if (step.parent >= 0 && positioned.has(step.parent)) {
+        const parentPos = positioned.get(step.parent);
+        const top = parentPos.y + height / 2;
+        const lineHeight = pos.y - height / 2 - top;
+        const arrowBlock = document.createElement("div");
+        arrowBlock.className = "arrowblock";
+        arrowBlock.style.left = `${pos.x - 5}px`;
+        arrowBlock.style.top = `${top}px`;
+        arrowBlock.style.height = `${Math.max(0, lineHeight)}px`;
+        arrowBlock.innerHTML = `
+          <input type="hidden" class="arrowid" value="${step.id}">
+          <svg preserveAspectRatio="none" fill="none" xmlns="http://www.w3.org/2000/svg" width="10" height="${Math.max(0, lineHeight)}">
+            <path d="M5 0 L5 ${Math.max(0, lineHeight - 8)}" stroke="#C5CCD0" stroke-width="2px"></path>
+            <path d="M0 ${Math.max(0, lineHeight - 8)} H10 L5 ${Math.max(0, lineHeight)} L0 ${Math.max(0, lineHeight - 8)} Z" fill="#C5CCD0"></path>
+          </svg>
+        `;
+        wrapper.appendChild(arrowBlock);
+      }
+    });
+
+    return {
+      html: wrapper.innerHTML,
+      blockarr,
+      blocks: []
+    };
+  }
+
+  function selectBlock(block) {
+    if (selectedBlock) {
+      const prev = selectedBlock.querySelector(".canvas-card");
+      if (prev) prev.classList.remove("selected");
     }
-}
-var checkTouch = function (event) {
-    aclick = false;
-}
-var doneTouch = function (event) {
-    if (event.type === "mouseup" && aclick && !noinfo) {
-      if (!rightcard && event.target.closest(".block") && !event.target.closest(".block").classList.contains("dragging")) {
-            tempblock = event.target.closest(".block");
-            rightcard = true;
-            document.getElementById("properties").classList.add("expanded");
-            document.getElementById("propwrap").classList.add("itson");
-            tempblock.classList.add("selectedblock");
-       } 
+    selectedBlock = block;
+    const card = block.querySelector(".canvas-card");
+    if (card) card.classList.add("selected");
+    Array.from(form.elements).forEach((el) => {
+      if (!el.name) return;
+      if (el.type === "checkbox") {
+        el.checked = getField(block, el.name) === "true";
+      } else {
+        el.value = getField(block, el.name) || "";
+      }
+    });
+  }
+
+  function persist() {
+    const out = flowy.output();
+    if (!out) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
     }
-}
-addEventListener("mousedown", beginTouch, false);
-addEventListener("mousemove", checkTouch, false);
-addEventListener("mouseup", doneTouch, false);
-addEventListenerMulti("touchstart", beginTouch, false, ".block");
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(out));
+  }
+
+  function restore() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      flowy.import(JSON.parse(raw), true);
+      document.querySelectorAll("#canvas .block").forEach((b) => {
+        if (!b.querySelector(".canvas-card")) hydrateBlock(b);
+        updateNodeCard(b);
+      });
+      refreshAnalytics();
+    } catch (err) {
+      console.error("Failed to restore workflow:", err);
+    }
+  }
+
+  form.addEventListener("input", (e) => {
+    if (!selectedBlock || !e.target.name) return;
+    const value = e.target.type === "checkbox" ? String(e.target.checked) : e.target.value;
+    setField(selectedBlock, e.target.name, value);
+    if (e.target.name === "risk" && e.target.value === "high") {
+      setField(selectedBlock, "approval", "true");
+      const approvalInput = form.elements.namedItem("approval");
+      approvalInput.checked = true;
+    }
+    updateNodeCard(selectedBlock);
+    clearTimeout(analyticsTimer);
+    analyticsTimer = setTimeout(refreshAnalytics, 150);
+  });
+
+  document.addEventListener("mouseup", (e) => {
+    const block = e.target.closest("#canvas .block");
+    if (!block || block.classList.contains("dragging")) return;
+    selectBlock(block);
+    refreshAnalytics();
+    persist();
+  });
+
+  document.getElementById("load-template").addEventListener("click", () => {
+    renderTemplates("");
+  });
+  document.getElementById("build-starter").addEventListener("click", () => {
+    flowy.deleteBlocks();
+    selectedBlock = null;
+    localStorage.removeItem(STORAGE_KEY);
+    const blocks = [
+      { id: 0, parent: -1, label: "Market & Competitive Research", person: "PMM Lead", tool: "Crayon / Sparktoro", input: "Market signals", output: "Research brief", datasource: "CRM / Web", loadHours: "6", frequency: "4", automation: "40", confidence: "82", dataQuality: "85", risk: "low", bucket: "assist", approval: "false" },
+      { id: 1, parent: 0, label: "Customer & ICP Discovery", person: "PMM", tool: "Dovetail / Typeform", input: "Customer interviews", output: "ICP profile", datasource: "CRM", loadHours: "8", frequency: "2", automation: "25", confidence: "80", dataQuality: "83", risk: "low", bucket: "assist", approval: "false" },
+      { id: 2, parent: 1, label: "Positioning Workshop", person: "PMM Lead + CPO", tool: "Miro / Notion", input: "ICP profile, research brief", output: "Positioning statement", datasource: "Internal docs", loadHours: "6", frequency: "2", automation: "10", confidence: "78", dataQuality: "80", risk: "medium", bucket: "human", approval: "true" },
+      { id: 3, parent: 2, label: "Messaging Architecture", person: "PMM", tool: "Notion", input: "Positioning statement", output: "Messaging framework", datasource: "Internal docs", loadHours: "5", frequency: "2", automation: "20", confidence: "80", dataQuality: "82", risk: "medium", bucket: "assist", approval: "true" },
+      { id: 4, parent: 3, label: "Go-to-Market Strategy", person: "PMM Lead + GTM Team", tool: "Notion / Airtable", input: "Messaging framework", output: "GTM plan", datasource: "CRM / Market data", loadHours: "8", frequency: "2", automation: "20", confidence: "79", dataQuality: "81", risk: "medium", bucket: "human", approval: "true" },
+      { id: 5, parent: 4, label: "Launch Asset Production", person: "PMM + Design", tool: "Figma / Notion", input: "GTM plan", output: "Launch assets", datasource: "Brand assets", loadHours: "10", frequency: "2", automation: "35", confidence: "82", dataQuality: "84", risk: "low", bucket: "assist", approval: "false" },
+      { id: 6, parent: 5, label: "Launch Execution", person: "PMM + Demand Gen", tool: "HubSpot / Salesforce", input: "Launch assets", output: "Live campaigns", datasource: "CRM / Ad platforms", loadHours: "8", frequency: "2", automation: "55", confidence: "85", dataQuality: "87", risk: "medium", bucket: "assist", approval: "true" },
+      { id: 7, parent: 6, label: "Post-Launch Performance Review", person: "PMM Lead", tool: "Tableau / GA4", input: "Campaign data", output: "Performance report", datasource: "CRM / Analytics", loadHours: "5", frequency: "4", automation: "50", confidence: "83", dataQuality: "86", risk: "low", bucket: "assist", approval: "false" },
+      { id: 8, parent: 0, label: "Weekly Competitive Signal Scan", person: "PMM Analyst", tool: "Crayon / Klue", input: "", output: "Battlecard updates", datasource: "", loadHours: "3", frequency: "5", automation: "70", confidence: "78", dataQuality: "72", risk: "low", bucket: "agent", approval: "false" },
+      { id: 9, parent: 8, label: "Battlecard Refresh", person: "PMM", tool: "Highspot", input: "", output: "Updated battlecards", datasource: "", loadHours: "2", frequency: "5", automation: "50", confidence: "82", dataQuality: "80", risk: "low", bucket: "assist", approval: "false" },
+      { id: 10, parent: 9, label: "Sales Alert Broadcast", person: "PMM", tool: "Slack / HubSpot", input: "", output: "Competitive alert to sales", datasource: "", loadHours: "1", frequency: "5", automation: "85", confidence: "88", dataQuality: "85", risk: "low", bucket: "agent", approval: "false" },
+      { id: 11, parent: 5, label: "Monthly Content Calendar Planning", person: "Content PMM", tool: "Notion / Airtable", input: "", output: "Monthly content plan", datasource: "", loadHours: "4", frequency: "4", automation: "30", confidence: "80", dataQuality: "82", risk: "low", bucket: "assist", approval: "false" },
+      { id: 12, parent: 11, label: "SEO & Keyword Review", person: "PMM + SEO", tool: "Semrush / Ahrefs", input: "", output: "Keyword priority list", datasource: "", loadHours: "3", frequency: "4", automation: "60", confidence: "85", dataQuality: "88", risk: "low", bucket: "assist", approval: "false" },
+      { id: 13, parent: 12, label: "Content Production Briefing", person: "PMM", tool: "Jasper / Notion", input: "", output: "Content briefs x8", datasource: "", loadHours: "5", frequency: "4", automation: "55", confidence: "78", dataQuality: "80", risk: "low", bucket: "assist", approval: "false" },
+      { id: 14, parent: 13, label: "Multi-Channel Publishing", person: "Content Ops", tool: "HubSpot / Buffer", input: "", output: "Published blog, social, email", datasource: "", loadHours: "4", frequency: "5", automation: "75", confidence: "84", dataQuality: "86", risk: "low", bucket: "agent", approval: "false" },
+      { id: 15, parent: 7, label: "Weekly Win/Loss Data Pull", person: "PMM Ops", tool: "Gong / Salesforce", input: "", output: "Win/loss report", datasource: "", loadHours: "2", frequency: "5", automation: "80", confidence: "87", dataQuality: "89", risk: "low", bucket: "agent", approval: "false" },
+      { id: 16, parent: 15, label: "Messaging Resonance Analysis", person: "PMM Lead", tool: "Chorus / Dovetail", input: "", output: "Message-market fit score", datasource: "", loadHours: "3", frequency: "4", automation: "45", confidence: "75", dataQuality: "78", risk: "medium", bucket: "assist", approval: "false" },
+      { id: 17, parent: 16, label: "Quarterly Positioning Refresh", person: "PMM Lead + CPO", tool: "Notion / Miro", input: "", output: "Updated positioning framework", datasource: "", loadHours: "8", frequency: "1", automation: "15", confidence: "74", dataQuality: "80", risk: "high", bucket: "human", approval: "true" },
+      { id: 18, parent: 4, label: "Sales Feedback Collection", person: "PMM + Sales Ops", tool: "Salesforce / Typeform", input: "", output: "Enablement gap report", datasource: "", loadHours: "3", frequency: "4", automation: "55", confidence: "80", dataQuality: "83", risk: "low", bucket: "assist", approval: "false" },
+      { id: 19, parent: 18, label: "Enablement Asset Update", person: "PMM", tool: "Highspot / Seismic", input: "", output: "Refreshed pitch decks, one-pagers", datasource: "", loadHours: "6", frequency: "2", automation: "35", confidence: "79", dataQuality: "82", risk: "medium", bucket: "assist", approval: "true" },
+      { id: 20, parent: 19, label: "Sales Training Session", person: "Enablement Manager", tool: "Zoom / LMS", input: "", output: "Trained reps + quiz score", datasource: "", loadHours: "4", frequency: "2", automation: "20", confidence: "85", dataQuality: "87", risk: "low", bucket: "human", approval: "false" }
+    ];
+    flowy.import(buildStarterFlowImport(blocks), true);
+    document.querySelectorAll("#canvas .block").forEach((b) => updateNodeCard(b));
+
+    refreshAnalytics();
+    persist();
+  });
+  document.getElementById("clear-canvas").addEventListener("click", () => {
+    flowy.deleteBlocks();
+    selectedBlock = null;
+    refreshAnalytics();
+    persist();
+  });
+  document.getElementById("save-local").addEventListener("click", persist);
+
+  document.getElementById("export-json").addEventListener("click", () => {
+    const data = flowy.output();
+    if (!data) return;
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "pmm-workflow.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  document.getElementById("import-json").addEventListener("change", (e) => {
+    const [file] = e.target.files || [];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const parsed = JSON.parse(String(reader.result));
+        flowy.import(parsed);
+        document.querySelectorAll("#canvas .block").forEach((b) => {
+          if (!b.querySelector(".canvas-card")) hydrateBlock(b);
+          updateNodeCard(b);
+        });
+        refreshAnalytics();
+        persist();
+      } catch (err) {
+        console.error("Failed to import workflow JSON:", err);
+      }
+    };
+    reader.readAsText(file);
+  });
+
+  search.addEventListener("input", () => renderTemplates(search.value));
+
+  renderTemplates();
+  restore();
+  refreshAnalytics();
 });

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -1,640 +1,117 @@
-body, html {
-    margin: 0px;
-    padding: 0px;
-    overflow: hidden;
-    background-image: url(assets/tile.png);
-    background-repeat: repeat;
-    background-size: 30px 30px;
-    background-color: #FBFBFB;
-    height: 100%;
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; font-family: "Space Grotesk", sans-serif; }
+body {
+  background:
+    radial-gradient(circle at 10% 20%, rgba(240, 220, 190, 0.35), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(175, 225, 205, 0.35), transparent 40%),
+    #f6f7f2;
+  color: #222;
 }
-#navigation {
-    height: 71px;
-    background-color: #FFF;
-    border: 1px solid #E8E8EF;
-    width: 100%;
-    display: table;
-    box-sizing: border-box;
-    position: fixed;
-    top: 0;
-    z-index: 9
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #d8d9cc;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(8px);
 }
-#back {
-    width: 40px;
-    height: 40px;
-    border-radius: 100px;
-    background-color: #F1F4FC;
-    text-align: center;
-    display: inline-block;
-    vertical-align: top;
-    margin-top: 12px;
-    margin-right: 10px
+.topbar h1 { margin: 0; font-size: 20px; }
+.topbar p { margin: 4px 0 0; color: #555; font-size: 12px; max-width: 660px; }
+.actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+button, .file-button {
+  border: 1px solid #1f1f1f;
+  background: #fff;
+  color: #1f1f1f;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
 }
-#back img {
-    margin-top: 13px;
-}
-#names {
-    display: inline-block;
-    vertical-align: top;
-}
-#title {
-    font-family: Roboto;
-    font-weight: 500;
-    font-size: 16px;
-    color: #393C44;
-    margin-bottom: 0px;
-}
-#subtitle {
-    font-family: Roboto;
-    color: #808292;
-    font-size: 14px;
-    margin-top: 5px;
-}
-#leftside {
-    display: inline-block;
-    vertical-align: middle;
-    margin-left: 20px;
-}
-#centerswitch {
-    position: absolute;
-    width: 222px;
-    left: 50%;
-    margin-left: -111px;
-    top: 15px;
-}
-#leftswitch {
-    border: 1px solid #E8E8EF;
-    background-color: #FBFBFB;
-    width: 111px;
-    height: 39px;
-    line-height: 39px;
-    border-radius: 5px 0px 0px 5px;
-    font-family: Roboto;
-    color: #393C44;
-    display: inline-block;
-    font-size: 14px;
-    text-align: center;
-}
-#rightswitch {
-    font-family: Roboto;
-    color: #808292;
-    border-radius: 0px 5px 5px 0px;
-    border: 1px solid #E8E8EF;
-    height: 39px;
-    width: 102px;
-    display: inline-block;
-    font-size: 14px;
-    line-height: 39px;
-    text-align: center;
-    margin-left: -5px;
-}
-#discard {
-    font-family: Roboto;
-    font-weight: 500;
-    font-size: 14px;
-    color: #A6A6B3;
-    width: 95px;
-    height: 38px;
-    border: 1px solid #E8E8EF;
-    border-radius: 5px;
-    text-align: center;
-    line-height: 38px;
-    display: inline-block;
-    vertical-align: top;
-    transition: all .2s cubic-bezier(.05,.03,.35,1);
-}
-#discard:hover {
-    cursor: pointer;
-    opacity: .7;
-}
-#publish {
-    font-family: Roboto;
-    font-weight: 500;
-    font-size: 14px;
-    color: #FFF;
-    background-color: #217CE8;
-    border-radius: 5px;
-    width: 143px;
-    height: 38px;
-    margin-left: 10px;
-    display: inline-block;
-    vertical-align: top;
-    text-align: center;
-    line-height: 38px;
-    margin-right: 20px;
-    transition: all .2s cubic-bezier(.05,.03,.35,1);
-}
-#publish:hover {
-    cursor: pointer;
-    opacity: .7;
-}
-#buttonsright {
-    float: right;
-    margin-top: 15px;
-}
-#leftcard {
-    width: 363px;
-    background-color: #FFF;
-    border: 1px solid #E8E8EF;
-    box-sizing: border-box;
-    padding-top: 85px;
-    padding-left: 20px;
-    height: 100%;
-    position: absolute;
-    z-index: 2;
-}
-#search input {
-    width: 318px;
-    height: 40px;
-    background-color: #FFF;
-    border: 1px solid #E8E8EF;
-    box-sizing: border-box;
-    box-shadow: 0px 2px 8px rgba(34,34,87,0.05);
-    border-radius: 5px;
-    text-indent: 35px;
-    font-family: Roboto;
-    font-size: 16px;
-}
-::-webkit-input-placeholder { /* Edge */
-  color: #C9C9D5;
-}
+button:hover, .file-button:hover { background: #f2f2ec; }
+button.danger { border-color: #8c2e2e; color: #8c2e2e; }
+.file-button { position: relative; overflow: hidden; display: inline-block; }
+.file-button input { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
 
-:-ms-input-placeholder { /* Internet Explorer 10-11 */
-  color: #C9C9D5
+.layout {
+  display: grid;
+  grid-template-columns: 320px 1fr 340px;
+  gap: 12px;
+  height: calc(100vh - 78px);
+  padding: 12px;
 }
+.panel {
+  border: 1px solid #d5d7c8;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  padding: 12px;
+}
+.panel h2 { margin: 0 0 10px; font-size: 16px; }
+.sidebar, .rightbar { overflow: auto; }
+#canvas-wrap {
+  border: 1px solid #d5d7c8;
+  border-radius: 8px;
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, rgba(70, 70, 70, 0.05) 1px, transparent 1px),
+    linear-gradient(rgba(70, 70, 70, 0.05) 1px, transparent 1px),
+    #fbfbf7;
+  background-size: 24px 24px;
+  position: relative;
+}
+#canvas { position: absolute; inset: 0; overflow: auto; }
 
-::placeholder {
-  color: #C9C9D5;
+#search-blocks, form input, form select {
+  width: 100%;
+  border: 1px solid #cfd2be;
+  border-radius: 6px;
+  padding: 8px;
+  font: inherit;
+  font-size: 13px;
+  background: #fff;
 }
-#search img {
-    position: absolute; 
-    margin-top: 10px;
-    width: 18px;
-    margin-left: 12px;
-}
-#header {
-    font-size: 20px;
-    font-family: Roboto;
-    font-weight: bold;
-    color: #393C44;
-}
-#subnav {
-    border-bottom: 1px solid #E8E8EF;
-    width: calc(100% + 20px);
-    margin-left: -20px;
-    margin-top: 10px;
-}
-.navdisabled {
-    transition: all .3s cubic-bezier(.05,.03,.35,1);
-}
-.navdisabled:hover {
-    cursor: pointer;
-    opacity: .5;
-}
-.navactive {
-    color: #393C44!important;
-}
-#triggers {
-    margin-left: 20px;
-    font-family: Roboto;
-    font-weight: 500;
-    font-size: 14px;
-    text-align: center;
-    color: #808292;
-    width: calc(88% / 3);
-    height: 48px;
-    line-height: 48px;
-    display: inline-block;
-    float: left;
-}
-.navactive:after {
-    display: block;
-    content: "";
-    width:  100%;
-    height: 4px;
-    background-color: #217CE8;
-    margin-top: -4px;
-}
-#actions {
-    display: inline-block;
-    font-family: Roboto;
-    font-weight: 500;
-    color: #808292;
-    font-size: 14px;
-    height: 48px;
-    line-height: 48px;
-    width: calc(88% / 3);
-    text-align: center;
-    float: left;
-}
-#loggers {
-    width: calc(88% / 3);
-    display: inline-block;
-    font-family: Roboto;
-    font-weight: 500;
-    color: #808292;
-    font-size: 14px;
-    height: 48px;
-    line-height: 48px;
-    text-align: center;
-}
-#footer {
-    position: absolute;
-    left: 0;
-    padding-left: 20px;
-    line-height: 40px;
-    bottom: 0;
-    width: 362px;
-    border: 1px solid #E8E8EF;
-    height: 67px;
-    box-sizing: border-box;
-    background-color: #FFF;
-    font-family: Roboto;
-    font-size: 14px;
-}
-#footer a {
-    text-decoration: none;
-    color: #393C44;
-    transition: all .2s cubic-bezier(.05,.03,.35,1);
-}
-#footer a:hover {
-    opacity: .5;
-}
-#footer span {
-    color: #808292;
-}
-#footer p {
-    display: inline-block;
-    color: #808292;
-}
-#footer img {
-    margin-left: 5px;
-    margin-right: 5px;
-}
-.blockelem:first-child {
-    margin-top: 20px
-}
+.blocklist { margin-top: 8px; display: grid; gap: 8px; }
 .blockelem {
-    padding-top: 10px;
-    width: 318px;
-    border: 1px solid transparent;
-    transition-property: box-shadow, height;
-    transition-duration: .2s;
-    transition-timing-function: cubic-bezier(.05,.03,.35,1);
-    border-radius: 5px;
-    box-shadow: 0px 0px 30px rgba(22, 33, 74, 0);
-    box-sizing: border-box;
+  border: 1px solid #d4d6c7;
+  border-radius: 8px;
+  background: #fff;
+  padding: 8px;
+  cursor: grab;
 }
-.blockelem:hover {
-    box-shadow: 0px 4px 30px rgba(22, 33, 74, 0.08);
-    border-radius: 5px;
-    background-color: #FFF;
-    cursor: pointer;
-}
-.grabme, .blockico {
-    display: inline-block;
-}
-.grabme {
-    margin-top: 10px;
-    margin-left: 10px;
-    margin-bottom: -14px;
-    width: 15px;
-}
-#blocklist {
-    height: calc(100% - 220px);
-    overflow: auto;
-}
-#proplist {
-    height: calc(100% - 305px);
-    overflow: auto;
-    margin-top: -30px;
-    padding-top: 30px;
-}
-.blockin {
-    display: inline-block;
-    vertical-align: top;
-    margin-left: 12px;
-}
-.blockico {
-    width: 36px;
-    height: 36px;
-    background-color: #F1F4FC;
-    border-radius: 5px;
-    text-align: center;
-    white-space: nowrap;
-}
-.blockico span {
-    height: 100%;
-    width: 0px;
-    display: inline-block;
-    vertical-align: middle;
-}
-.blockico img {
-    vertical-align: middle;
-    margin-left: auto;
-    margin-right: auto;
-    display: inline-block;
-}
-.blocktext {
-    display: inline-block;
-    width: 220px;
-    vertical-align: top;
-    margin-left: 12px
-}
-.blocktitle {
-    margin: 0px!important;
-    padding: 0px!important;
-    font-family: Roboto;
-    font-weight: 500;
-    font-size: 16px;
-    color: #393C44;
-}
-.blockdesc {
-    margin-top: 5px;
-    font-family: Roboto;
-    color: #808292;
-    font-size: 14px;
-    line-height: 21px;
-}
-.blockdisabled {
-    background-color: #F0F2F9;
-    opacity: .5;
-}
-#closecard {
-    position: absolute;
-    margin-left: 340px;
-    background-color: #FFF;
-    border-radius: 0px 5px 5px 0px;
-    border-bottom: 1px solid #E8E8EF;
-    border-right: 1px solid #E8E8EF;
-    border-top: 1px solid #E8E8EF;
-    width: 53px;
-    height: 53px;
-    text-align: center; 
-    z-index: 10;
-}
-#closecard img {
-    margin-top: 15px
-}
-#canvas {
-    position: absolute;
-    width: calc(100% - 361px);
-    height: calc(100% - 71px);
-    top: 71px;
-    left: 361px;
-    z-index: 0;
-    overflow: auto;
-}
-#propwrap {
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: 311px;
-    height: 100%;
-    padding-left: 20px;
-    overflow: hidden;
-    z-index: -2;
-}
-#properties {
-    position: absolute;
-    height: 100%;
-    width: 311px;
-    background-color: #FFF;
-    right: -150px;
-    opacity: 0;
-    z-index: 2;
-    top: 0px;
-    box-shadow: -4px 0px 40px rgba(26, 26, 73, 0);
-    padding-left: 20px;
-    transition: all .25s cubic-bezier(.05,.03,.35,1);
-}
-.itson {
-    z-index: 2!important;
-}
-.expanded {
-    right: 0!important;
-    opacity: 1!important;
-    box-shadow: -4px 0px 40px rgba(26, 26, 73, 0.05);
-        z-index: 2;
-}
-#header2 {
-    font-size: 20px;
-    font-family: Roboto;
-    font-weight: bold;
-    color: #393C44;
-    margin-top: 101px;
-}
-#close {
-    margin-top: 100px;
-    position: absolute;
-    right: 20px;
-    z-index: 9999;
-    transition: all .25s cubic-bezier(.05,.03,.35,1);
-}
-#close:hover {
-    cursor: pointer;
-    opacity: .7;
-}
-#propswitch {
-    border-bottom: 1px solid #E8E8EF;
-    width: 331px;
-    margin-top: 10px;
-    margin-left: -20px;
-    margin-bottom: 30px;
-}
-#dataprop {
-    font-family: Roboto;
-    font-weight: 500;
-    font-size: 14px;
-    text-align: center;
-    color: #393C44;
-    width: calc(88% / 3);
-    height: 48px;
-    line-height: 48px;
-    display: inline-block;
-    float: left;
-    margin-left: 20px;
-}
-#dataprop:after {
-    display: block;
-    content: "";
-    width: 100%;
-    height: 4px;
-    background-color: #217CE8;
-    margin-top: -4px;
-}
-#alertprop {
-    display: inline-block;
-    font-family: Roboto;
-    font-weight: 500;
-    color: #808292;
-    font-size: 14px;
-    height: 48px;
-    line-height: 48px;
-    width: calc(88% / 3);
-    text-align: center;
-    float: left;
-}
-#logsprop {
-    width: calc(88% / 3);
-    display: inline-block;
-    font-family: Roboto;
-    font-weight: 500;
-    color: #808292;
-    font-size: 14px;
-    height: 48px;
-    line-height: 48px;
-    text-align: center;
-}
-.inputlabel {
-    font-family: Roboto;
-    font-size: 14px;
-    color: #253134;
-}
-.dropme {
-    background-color: #FFF;
-    border-radius: 5px;
-    border: 1px solid #E8E8EF;
-    box-shadow: 0px 2px 8px rgba(34, 34, 87, 0.05);
-    font-family: Roboto;
-    font-size: 14px;
-    color: #253134;
-    text-indent: 20px;
-    height: 40px;
-    line-height: 40px;
-    width: 287px;
-    margin-bottom: 25px;
-}
-.dropme img {
-    margin-top: 17px;
-    float: right;
-    margin-right: 15px;
-}
-.checkus {
-    margin-bottom: 10px;
-}
-.checkus img {
-    display: inline-block;
-    vertical-align: middle;
-}
-.checkus p {
-    display: inline-block;
-    font-family: Roboto;
-    font-size: 14px;
-    vertical-align: middle;
-    margin-left: 10px;
-}
-#divisionthing {
-    height: 1px;
-    width: 100%;
-    background-color: #E8E8EF;
-    position: absolute;
-    right: 0px;
-    bottom: 80;
-}
-#removeblock {
-    border-radius: 5px;
-    position: absolute;
-    bottom: 20px;
-    font-family: Roboto;
-    font-size: 14px;
-    text-align: center;
-    width: 287px;
-    height: 38px;
-    line-height: 38px;
-    color: #253134;
-    border: 1px solid #E8E8EF;
-    transition: all .3s cubic-bezier(.05,.03,.35,1);
-}
-#removeblock:hover {
-    cursor: pointer;
-    opacity: .5;
-}
-.noselect {
-  -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-     -khtml-user-select: none; /* Konqueror HTML */
-       -moz-user-select: none; /* Old versions of Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome, Opera and Firefox */
-}
-.blockyname {
-    font-family: Roboto;
-    font-weight: 500;
-    color: #253134;
-    display: inline-block;
-    vertical-align: middle;
-    margin-left: 8px;
-    font-size: 16px;
-}
-.blockyleft img {
-    display: inline-block;
-    vertical-align: middle;
-}
-.blockyright {
-    display: inline-block;
-    float: right;
-    vertical-align: middle;
-    margin-right: 20px;
-    margin-top: 10px;
-    width: 28px;
-    height: 28px;
-    border-radius: 5px;
-    text-align: center; 
-    background-color: #FFF;
-    transition: all .3s cubic-bezier(.05,.03,.35,1);
-    z-index: 10;
-}
-.blockyright:hover {
-    background-color: #F1F4FC;
-    cursor: pointer;
-}
-.blockyright img {
-    margin-top: 12px;
-}
-.blockyleft {
-    display: inline-block;
-    margin-left: 20px;
-}
-.blockydiv {
-    width: 100%;
-    height: 1px;
-    background-color: #E9E9EF;
-}
-.blockyinfo {
-    font-family: Roboto;
-    font-size: 14px;
-    color: #808292;
-    margin-top: 15px;
-    text-indent: 20px;
-    margin-bottom: 20px;
-}
-.blockyinfo span {
-    color: #253134;
-    font-weight: 500;
-    display: inline-block;
-    border-bottom: 1px solid #D3DCEA;
-    line-height: 20px;
-    text-indent: 0px;
-}
-.block {
-    background-color: #FFF;
-    margin-top: 0px!important;
-    box-shadow: 0px 4px 30px rgba(22, 33, 74, 0.05);
-}
-.selectedblock {
-    border: 2px solid #217CE8;
-    box-shadow: 0px 4px 30px rgba(22, 33, 74, 0.08);
-}
+.blockelem:hover { border-color: #81917a; }
+.blockin { display: grid; gap: 4px; }
+.blocktitle { margin: 0; font-weight: 700; font-size: 13px; }
+.blockdesc { margin: 0; color: #666; font-size: 12px; }
+.blocktag { font-size: 11px; color: #47624a; }
 
-@media only screen and (max-width: 832px) {
-    #centerswitch {
-        display: none;
-    }
+form { display: grid; gap: 8px; }
+label { display: grid; gap: 4px; font-size: 12px; color: #3d4033; }
+.check-row { display: flex; align-items: center; gap: 8px; }
+.check-row input { width: auto; }
+
+.canvas-card {
+  border: 1px solid #c8cfb8;
+  border-radius: 8px;
+  background: #fffdf8;
+  min-width: 230px;
+  padding: 10px;
 }
-@media only screen and (max-width: 560px) {
-    #names {
-        display: none;
-    }   
+.canvas-card h4 { margin: 0 0 6px; font-size: 14px; }
+.canvas-card p { margin: 3px 0; font-size: 12px; color: #4b4e43; }
+.canvas-card.selected { border-color: #2f6f48; box-shadow: 0 0 0 2px rgba(47, 111, 72, 0.2); }
+
+#analytics { font-size: 12px; color: #2f302a; display: grid; gap: 8px; }
+.metric { padding: 8px; border-radius: 6px; background: #f2f5ea; border: 1px solid #dce5cd; }
+.table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.table th, .table td { border-bottom: 1px solid #e5e7d8; text-align: left; padding: 6px 4px; }
+
+@media (max-width: 1200px) {
+  .layout { grid-template-columns: 280px 1fr; grid-template-rows: 1fr 300px; }
+  .rightbar { grid-column: 1 / span 2; }
+}
+@media (max-width: 760px) {
+  .layout { display: flex; flex-direction: column; height: auto; }
+  #canvas-wrap { min-height: 520px; }
 }

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -115,3 +115,35 @@ label { display: grid; gap: 4px; font-size: 12px; color: #3d4033; }
   .layout { display: flex; flex-direction: column; height: auto; }
   #canvas-wrap { min-height: 520px; }
 }
+#zoom-controls {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255,255,255,0.92);
+  border: 1px solid #d5d7c8;
+  border-radius: 8px;
+  padding: 4px 8px;
+  backdrop-filter: blur(6px);
+}
+#zoom-controls button {
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+#zoom-controls button:hover { background: #f2f2ec; }
+#zoom-controls button:disabled { opacity: 0.35; cursor: default; }
+#zoom-label {
+  font-size: 12px;
+  min-width: 36px;
+  text-align: center;
+  color: #3d4033;
+  font-weight: 500;
+}

--- a/engine/flowy.js
+++ b/engine/flowy.js
@@ -63,7 +63,7 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
         el.classList.add('indicator');
         el.classList.add('invisible');
         canvas_div.appendChild(el);
-        flowy.import = function(output) {
+        flowy.import = function(output, skipRearrange) {
             canvas_div.innerHTML = output.html;
             for (var a = 0; a < output.blockarr.length; a++) {
                 blocks.push({
@@ -76,7 +76,7 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                     height: parseFloat(output.blockarr[a].height)
                 })
             }
-            if (blocks.length > 1) {
+            if (!skipRearrange && blocks.length > 1) {
                 rearrangeMe();
                 checkOffset();
             }
@@ -273,14 +273,15 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
         }
         
         function drawArrow(arrow, x, y, id) {
+            const parentBlock = blocks.filter(a => a.id == id)[0];
             if (x < 0) {
-                canvas_div.innerHTML += '<div class="arrowblock"><input type="hidden" class="arrowid" value="' + drag.querySelector(".blockid").value + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M' + (blocks.filter(a => a.id == id)[0].x - arrow.x + 5) + ' 0L' + (blocks.filter(a => a.id == id)[0].x - arrow.x + 5) + ' ' + (paddingy / 2) + 'L5 ' + (paddingy / 2) + 'L5 ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M0 ' + (y - 5) + 'H10L5 ' + y + 'L0 ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg></div>';
+                canvas_div.insertAdjacentHTML("beforeend", '<div class="arrowblock"><input type="hidden" class="arrowid" value="' + drag.querySelector(".blockid").value + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M' + (parentBlock.x - arrow.x + 5) + ' 0L' + (parentBlock.x - arrow.x + 5) + ' ' + (paddingy / 2) + 'L5 ' + (paddingy / 2) + 'L5 ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M0 ' + (y - 5) + 'H10L5 ' + y + 'L0 ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg></div>');
                 document.querySelector('.arrowid[value="' + drag.querySelector(".blockid").value + '"]').parentNode.style.left = (arrow.x - 5) - (absx + window.scrollX) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
             } else {
-                canvas_div.innerHTML += '<div class="arrowblock"><input type="hidden" class="arrowid" value="' + drag.querySelector(".blockid").value + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0L20 ' + (paddingy / 2) + 'L' + (x) + ' ' + (paddingy / 2) + 'L' + x + ' ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M' + (x - 5) + ' ' + (y - 5) + 'H' + (x + 5) + 'L' + x + ' ' + y + 'L' + (x - 5) + ' ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg></div>';
-                document.querySelector('.arrowid[value="' + parseInt(drag.querySelector(".blockid").value) + '"]').parentNode.style.left = blocks.filter(a => a.id == id)[0].x - 20 - (absx + window.scrollX) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
+                canvas_div.insertAdjacentHTML("beforeend", '<div class="arrowblock"><input type="hidden" class="arrowid" value="' + drag.querySelector(".blockid").value + '"><svg preserveaspectratio="none" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0L20 ' + (paddingy / 2) + 'L' + (x) + ' ' + (paddingy / 2) + 'L' + x + ' ' + y + '" stroke="#C5CCD0" stroke-width="2px"/><path d="M' + (x - 5) + ' ' + (y - 5) + 'H' + (x + 5) + 'L' + x + ' ' + y + 'L' + (x - 5) + ' ' + (y - 5) + 'Z" fill="#C5CCD0"/></svg></div>');
+                document.querySelector('.arrowid[value="' + parseInt(drag.querySelector(".blockid").value) + '"]').parentNode.style.left = parentBlock.x - 20 - (absx + window.scrollX) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
             }
-            document.querySelector('.arrowid[value="' + parseInt(drag.querySelector(".blockid").value) + '"]').parentNode.style.top = blocks.filter(a => a.id == id)[0].y + (blocks.filter(a => a.id == id)[0].height / 2) + canvas_div.getBoundingClientRect().top - absy + "px";
+            document.querySelector('.arrowid[value="' + parseInt(drag.querySelector(".blockid").value) + '"]').parentNode.style.top = parentBlock.y + (parentBlock.height / 2) + canvas_div.getBoundingClientRect().top - absy + "px";
         }
         
         function updateArrow(arrow, x, y, children) { 
@@ -297,11 +298,13 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             if (!rearrange) {
                 canvas_div.appendChild(drag);
             }
+            const parentId = blocko[i];
+            const parentBlock = blocks.filter(id => id.id == parentId)[0];
+            const parentChildren = blocks.filter(id => id.parent == parentId);
             var totalwidth = 0;
             var totalremove = 0;
-            var maxheight = 0;
-            for (var w = 0; w < blocks.filter(id => id.parent == blocko[i]).length; w++) {
-                var children = blocks.filter(id => id.parent == blocko[i])[w];
+            for (var w = 0; w < parentChildren.length; w++) {
+                var children = parentChildren[w];
                 if (children.childwidth > children.width) {
                     totalwidth += children.childwidth + paddingx;
                 } else {
@@ -309,24 +312,24 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                 }
             }
             totalwidth += parseInt(window.getComputedStyle(drag).width);
-            for (var w = 0; w < blocks.filter(id => id.parent == blocko[i]).length; w++) {
-                var children = blocks.filter(id => id.parent == blocko[i])[w];
+            for (var w = 0; w < parentChildren.length; w++) {
+                var children = parentChildren[w];
                 if (children.childwidth > children.width) {
-                    document.querySelector(".blockid[value='" + children.id + "']").parentNode.style.left = blocks.filter(a => a.id == blocko[i])[0].x - (totalwidth / 2) + totalremove + (children.childwidth / 2) - (children.width / 2) + "px";
-                    children.x = blocks.filter(id => id.parent == blocko[i])[0].x - (totalwidth / 2) + totalremove + (children.childwidth / 2);
+                    document.querySelector(".blockid[value='" + children.id + "']").parentNode.style.left = parentBlock.x - (totalwidth / 2) + totalremove + (children.childwidth / 2) - (children.width / 2) + "px";
+                    children.x = parentBlock.x - (totalwidth / 2) + totalremove + (children.childwidth / 2);
                     totalremove += children.childwidth + paddingx;
                 } else {
-                    document.querySelector(".blockid[value='" + children.id + "']").parentNode.style.left = blocks.filter(a => a.id == blocko[i])[0].x - (totalwidth / 2) + totalremove + "px";
-                    children.x = blocks.filter(id => id.parent == blocko[i])[0].x - (totalwidth / 2) + totalremove + (children.width / 2);
+                    document.querySelector(".blockid[value='" + children.id + "']").parentNode.style.left = parentBlock.x - (totalwidth / 2) + totalremove + "px";
+                    children.x = parentBlock.x - (totalwidth / 2) + totalremove + (children.width / 2);
                     totalremove += children.width + paddingx;
                 }
             }
-            drag.style.left = blocks.filter(id => id.id == blocko[i])[0].x - (totalwidth / 2) + totalremove - (window.scrollX + absx) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
-            drag.style.top = blocks.filter(id => id.id == blocko[i])[0].y + (blocks.filter(id => id.id == blocko[i])[0].height / 2) + paddingy - (window.scrollY + absy) + canvas_div.getBoundingClientRect().top + "px";
+            drag.style.left = parentBlock.x - (totalwidth / 2) + totalremove - (window.scrollX + absx) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
+            drag.style.top = parentBlock.y + (parentBlock.height / 2) + paddingy - (window.scrollY + absy) + canvas_div.getBoundingClientRect().top + "px";
             if (rearrange) {
                 blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].x = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
                 blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].y = (drag.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
-                blockstemp.filter(a => a.id == drag.querySelector(".blockid").value)[0].parent = blocko[i];
+                blockstemp.filter(a => a.id === parseInt(drag.querySelector(".blockid").value))[0].parent = blocko[i];
                 for (var w = 0; w < blockstemp.length; w++) {
                     if (blockstemp[w].id != parseInt(drag.querySelector(".blockid").value)) {
                         const blockParent = document.querySelector(".blockid[value='" + blockstemp[w].id + "']").parentNode;
@@ -357,11 +360,11 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             }
             
             var arrowblock = blocks.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0];
-            var arrowx = arrowblock.x - blocks.filter(a => a.id == blocko[i])[0].x + 20;
+            var arrowx = arrowblock.x - parentBlock.x + 20;
             var arrowy = paddingy;
-            drawArrow(arrowblock, arrowx, arrowy, blocko[i]);
+            drawArrow(arrowblock, arrowx, arrowy, parentId);
             
-            if (blocks.filter(a => a.id == blocko[i])[0].parent != -1) {
+            if (parentBlock.parent != -1) {
                 var flag = false;
                 var idval = blocko[i];
                 while (!flag) {
@@ -511,7 +514,7 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                 } else if (mouse_y > canvas_div.getBoundingClientRect().height + canvas_div.getBoundingClientRect().top - 10 && mouse_y < canvas_div.getBoundingClientRect().height + canvas_div.getBoundingClientRect().top + 10) {
                     canvas_div.scrollTop += 10;
                 } else if (mouse_y < canvas_div.getBoundingClientRect().top + 10 && mouse_y > canvas_div.getBoundingClientRect().top - 10) {
-                    canvas_div.scrollLeft -= 10;
+                    canvas_div.scrollTop -= 10;
                 }
                 var xpos = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
                 var ypos = (drag.getBoundingClientRect().top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
@@ -542,14 +545,16 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             if (offsetleft < (canvas_div.getBoundingClientRect().left + window.scrollX - absx)) {
                 var blocko = blocks.map(a => a.id);
                 for (var w = 0; w < blocks.length; w++) {
-                    document.querySelector(".blockid[value='" + blocks.filter(a => a.id == blocko[w])[0].id + "']").parentNode.style.left = blocks.filter(a => a.id == blocko[w])[0].x - (blocks.filter(a => a.id == blocko[w])[0].width / 2) - offsetleft + canvas_div.getBoundingClientRect().left - absx + 20 + "px";
-                    if (blocks.filter(a => a.id == blocko[w])[0].parent != -1) {
-                        var arrowblock = blocks.filter(a => a.id == blocko[w])[0];
-                        var arrowx = arrowblock.x - blocks.filter(a => a.id == blocks.filter(a => a.id == blocko[w])[0].parent)[0].x;
+                    const block = blocks.filter(a => a.id == blocko[w])[0];
+                    document.querySelector(".blockid[value='" + block.id + "']").parentNode.style.left = block.x - (block.width / 2) - offsetleft + canvas_div.getBoundingClientRect().left - absx + 20 + "px";
+                    if (block.parent != -1) {
+                        var arrowblock = block;
+                        var parent = blocks.filter(a => a.id == block.parent)[0];
+                        var arrowx = arrowblock.x - parent.x;
                         if (arrowx < 0) {
                             document.querySelector('.arrowid[value="' + blocko[w] + '"]').parentNode.style.left = (arrowblock.x - offsetleft + 20 - 5) + canvas_div.getBoundingClientRect().left - absx + "px";
                         } else {
-                            document.querySelector('.arrowid[value="' + blocko[w] + '"]').parentNode.style.left = blocks.filter(id => id.id == blocks.filter(a => a.id == blocko[w])[0].parent)[0].x - 20 - offsetleft + canvas_div.getBoundingClientRect().left - absx + 20 + "px";
+                            document.querySelector('.arrowid[value="' + blocko[w] + '"]').parentNode.style.left = parent.x - 20 - offsetleft + canvas_div.getBoundingClientRect().left - absx + 20 + "px";
                         }
                     }
                 }
@@ -567,35 +572,36 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                 }
                 var totalwidth = 0;
                 var totalremove = 0;
-                var maxheight = 0;
-                for (var w = 0; w < blocks.filter(id => id.parent == result[z]).length; w++) {
-                    var children = blocks.filter(id => id.parent == result[z])[w];
+                const currentParent = result[z];
+                const childrenByParent = blocks.filter(id => id.parent == currentParent);
+                for (var w = 0; w < childrenByParent.length; w++) {
+                    var children = childrenByParent[w];
                     if (blocks.filter(id => id.parent == children.id).length == 0) {
                         children.childwidth = 0;
                     }
                     if (children.childwidth > children.width) {
-                        if (w == blocks.filter(id => id.parent == result[z]).length - 1) {
+                        if (w == childrenByParent.length - 1) {
                             totalwidth += children.childwidth;
                         } else {
                             totalwidth += children.childwidth + paddingx;
                         }
                     } else {
-                        if (w == blocks.filter(id => id.parent == result[z]).length - 1) {
+                        if (w == childrenByParent.length - 1) {
                             totalwidth += children.width;
                         } else {
                             totalwidth += children.width + paddingx;
                         }
                     }
                 }
-                if (result[z] != -1) {
-                    blocks.filter(a => a.id == result[z])[0].childwidth = totalwidth;
+                if (currentParent != -1) {
+                    blocks.filter(a => a.id == currentParent)[0].childwidth = totalwidth;
                 }
-                for (var w = 0; w < blocks.filter(id => id.parent == result[z]).length; w++) {
-                    var children = blocks.filter(id => id.parent == result[z])[w];
+                for (var w = 0; w < childrenByParent.length; w++) {
+                    var children = childrenByParent[w];
                     const r_block = document.querySelector(".blockid[value='" + children.id + "']").parentNode;
-                    const r_array = blocks.filter(id => id.id == result[z]);
-                    r_block.style.top = r_array.y + paddingy + canvas_div.getBoundingClientRect().top - absy + "px";
-                    r_array.y = r_array.y + paddingy;
+                    const r_array = blocks.filter(id => id.id == currentParent);
+                    r_block.style.top = r_array[0].y + paddingy + canvas_div.getBoundingClientRect().top - absy + "px";
+                    r_array[0].y = r_array[0].y + paddingy;
                     if (children.childwidth > children.width) {
                         r_block.style.left = r_array[0].x - (totalwidth / 2) + totalremove + (children.childwidth / 2) - (children.width / 2) - (absx + window.scrollX) + canvas_div.getBoundingClientRect().left + "px";
                         children.x = r_array[0].x - (totalwidth / 2) + totalremove + (children.childwidth / 2);
@@ -618,14 +624,24 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
         document.addEventListener("mousedown", touchblock, false);
         document.addEventListener("touchstart", flowy.beginDrag);
         document.addEventListener("touchstart", touchblock, false);
-        
-
         document.addEventListener("mouseup", touchblock, false);
         document.addEventListener("mousemove", flowy.moveBlock, false);
         document.addEventListener("touchmove", flowy.moveBlock, false);
-
         document.addEventListener("mouseup", flowy.endDrag, false);
         document.addEventListener("touchend", flowy.endDrag, false);
+
+        flowy.destroy = function() {
+            document.removeEventListener("mousedown", flowy.beginDrag);
+            document.removeEventListener("mousedown", touchblock, false);
+            document.removeEventListener("touchstart", flowy.beginDrag);
+            document.removeEventListener("touchstart", touchblock, false);
+            document.removeEventListener("mouseup", touchblock, false);
+            document.removeEventListener("mousemove", flowy.moveBlock, false);
+            document.removeEventListener("touchmove", flowy.moveBlock, false);
+            document.removeEventListener("mouseup", flowy.endDrag, false);
+            document.removeEventListener("touchend", flowy.endDrag, false);
+            loaded = false;
+        };
     }
 
     function blockGrabbed(block) {
@@ -644,19 +660,5 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
         return rearrange(drag, parent);
     }
 
-    function addEventListenerMulti(type, listener, capture, selector) {
-        var nodes = document.querySelectorAll(selector);
-        for (var i = 0; i < nodes.length; i++) {
-            nodes[i].addEventListener(type, listener, capture);
-        }
-    }
-
-    function removeEventListenerMulti(type, listener, capture, selector) {
-        var nodes = document.querySelectorAll(selector);
-        for (var i = 0; i < nodes.length; i++) {
-            nodes[i].removeEventListener(type, listener, capture);
-        }
-    }
-    
     flowy.load();
 }

--- a/engine/flowy.js
+++ b/engine/flowy.js
@@ -51,6 +51,7 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             absy = canvas_div.getBoundingClientRect().top;
         }
         var active = false;
+        var zoom = 1;
         var paddingx = spacing_x;
         var paddingy = spacing_y;
         var offsetleft = 0;
@@ -63,6 +64,21 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
         el.classList.add('indicator');
         el.classList.add('invisible');
         canvas_div.appendChild(el);
+        flowy.setZoom = function(level) {
+            zoom = level;
+        }
+
+        function scaled(rect) {
+            return {
+                left: rect.left / zoom,
+                top: rect.top / zoom,
+                right: rect.right / zoom,
+                bottom: rect.bottom / zoom,
+                width: rect.width / zoom,
+                height: rect.height / zoom
+            };
+        }
+
         flowy.import = function(output, skipRearrange) {
             canvas_div.innerHTML = output.html;
             for (var a = 0; a < output.blockarr.length; a++) {
@@ -125,11 +141,11 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                 absy = canvas_div.getBoundingClientRect().top;
             }
             if (event.targetTouches) {
-                mouse_x = event.changedTouches[0].clientX;
-                mouse_y = event.changedTouches[0].clientY;
+                mouse_x = event.changedTouches[0].clientX / zoom;
+                mouse_y = event.changedTouches[0].clientY / zoom;
             } else {
-                mouse_x = event.clientX;
-                mouse_y = event.clientY;
+                mouse_x = event.clientX / zoom;
+                mouse_y = event.clientY / zoom;
             }
             if (event.which != 3 && event.target.closest(".create-flowy")) {
                 original = event.target.closest(".create-flowy");
@@ -169,7 +185,7 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                 }
                 if (parseInt(drag.querySelector(".blockid").value) === 0 && rearrange) {
                     firstBlock("rearrange")    
-                } else if (active && blocks.length == 0 && (drag.getBoundingClientRect().top + window.scrollY) > (canvas_div.getBoundingClientRect().top + window.scrollY) && (drag.getBoundingClientRect().left + window.scrollX) > (canvas_div.getBoundingClientRect().left + window.scrollX)) {
+                } else if (active && blocks.length == 0 && (scaled(drag.getBoundingClientRect()).top + window.scrollY) > (canvas_div.getBoundingClientRect().top + window.scrollY) && (scaled(drag.getBoundingClientRect()).left + window.scrollX) > (canvas_div.getBoundingClientRect().left + window.scrollX)) {
                     firstBlock("drop");
                 } else if (active && blocks.length == 0) {
                     removeSelection();
@@ -218,8 +234,8 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
         }
         
         function checkAttach(id) {
-            const xpos = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
-            const ypos = (drag.getBoundingClientRect().top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+            const xpos = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+            const ypos = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
             if (xpos >= blocks.filter(a => a.id == id)[0].x - (blocks.filter(a => a.id == id)[0].width / 2) - paddingx && xpos <= blocks.filter(a => a.id == id)[0].x + (blocks.filter(a => a.id == id)[0].width / 2) + paddingx && ypos >= blocks.filter(a => a.id == id)[0].y - (blocks.filter(a => a.id == id)[0].height / 2) && ypos <= blocks.filter(a => a.id == id)[0].y + blocks.filter(a => a.id == id)[0].height) {
                 return true;   
             } else {
@@ -236,15 +252,15 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             if (type == "drop") {
                 blockSnap(drag, true, undefined);
                 active = false;
-                drag.style.top = (drag.getBoundingClientRect().top + window.scrollY) - (absy + window.scrollY) + canvas_div.scrollTop + "px";
-                drag.style.left = (drag.getBoundingClientRect().left + window.scrollX) - (absx + window.scrollX) + canvas_div.scrollLeft + "px";
+                drag.style.top = (scaled(drag.getBoundingClientRect()).top + window.scrollY) - (absy + window.scrollY) + canvas_div.scrollTop + "px";
+                drag.style.left = (scaled(drag.getBoundingClientRect()).left + window.scrollX) - (absx + window.scrollX) + canvas_div.scrollLeft + "px";
                 canvas_div.appendChild(drag);
                 blocks.push({
                     parent: -1,
                     childwidth: 0,
                     id: parseInt(drag.querySelector(".blockid").value),
-                    x: (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left,
-                    y: (drag.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top,
+                    x: (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left,
+                    y: (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top,
                     width: parseInt(window.getComputedStyle(drag).width),
                     height: parseInt(window.getComputedStyle(drag).height)
                 });
@@ -255,18 +271,18 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                     if (blockstemp[w].id != parseInt(drag.querySelector(".blockid").value)) {
                         const blockParent = document.querySelector(".blockid[value='" + blockstemp[w].id + "']").parentNode;
                         const arrowParent = document.querySelector(".arrowid[value='" + blockstemp[w].id + "']").parentNode;
-                        blockParent.style.left = (blockParent.getBoundingClientRect().left + window.scrollX) - (window.scrollX) + canvas_div.scrollLeft - 1 - absx + "px";
-                        blockParent.style.top = (blockParent.getBoundingClientRect().top + window.scrollY) - (window.scrollY) + canvas_div.scrollTop - absy - 1 + "px";
+                        blockParent.style.left = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) - (window.scrollX) + canvas_div.scrollLeft - 1 - absx + "px";
+                        blockParent.style.top = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) - (window.scrollY) + canvas_div.scrollTop - absy - 1 + "px";
                         arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (window.scrollX) + canvas_div.scrollLeft - absx - 1 + "px";
                         arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) + canvas_div.scrollTop - 1 - absy + "px";
                         canvas_div.appendChild(blockParent);
                         canvas_div.appendChild(arrowParent);
-                        blockstemp[w].x = (blockParent.getBoundingClientRect().left + window.scrollX) + (parseInt(blockParent.offsetWidth) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left - 1;
-                        blockstemp[w].y = (blockParent.getBoundingClientRect().top + window.scrollY) + (parseInt(blockParent.offsetHeight) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top - 1;
+                        blockstemp[w].x = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) + (parseInt(blockParent.offsetWidth) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left - 1;
+                        blockstemp[w].y = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) + (parseInt(blockParent.offsetHeight) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top - 1;
                     }
                 }
-                blockstemp.filter(a => a.id == 0)[0].x = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
-                blockstemp.filter(a => a.id == 0)[0].y = (drag.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                blockstemp.filter(a => a.id == 0)[0].x = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                blockstemp.filter(a => a.id == 0)[0].y = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
                 blocks = blocks.concat(blockstemp);
                 blockstemp = [];
             }
@@ -327,22 +343,22 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             drag.style.left = parentBlock.x - (totalwidth / 2) + totalremove - (window.scrollX + absx) + canvas_div.scrollLeft + canvas_div.getBoundingClientRect().left + "px";
             drag.style.top = parentBlock.y + (parentBlock.height / 2) + paddingy - (window.scrollY + absy) + canvas_div.getBoundingClientRect().top + "px";
             if (rearrange) {
-                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].x = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
-                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].y = (drag.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].x = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value))[0].y = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
                 blockstemp.filter(a => a.id === parseInt(drag.querySelector(".blockid").value))[0].parent = blocko[i];
                 for (var w = 0; w < blockstemp.length; w++) {
                     if (blockstemp[w].id != parseInt(drag.querySelector(".blockid").value)) {
                         const blockParent = document.querySelector(".blockid[value='" + blockstemp[w].id + "']").parentNode;
                         const arrowParent = document.querySelector(".arrowid[value='" + blockstemp[w].id + "']").parentNode;
-                        blockParent.style.left = (blockParent.getBoundingClientRect().left + window.scrollX) - (window.scrollX + canvas_div.getBoundingClientRect().left) + canvas_div.scrollLeft + "px";
-                        blockParent.style.top = (blockParent.getBoundingClientRect().top + window.scrollY) - (window.scrollY + canvas_div.getBoundingClientRect().top) + canvas_div.scrollTop + "px";
+                        blockParent.style.left = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) - (window.scrollX + canvas_div.getBoundingClientRect().left) + canvas_div.scrollLeft + "px";
+                        blockParent.style.top = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) - (window.scrollY + canvas_div.getBoundingClientRect().top) + canvas_div.scrollTop + "px";
                         arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (window.scrollX + canvas_div.getBoundingClientRect().left) + canvas_div.scrollLeft + 20 + "px";
                         arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) - (window.scrollY + canvas_div.getBoundingClientRect().top) + canvas_div.scrollTop + "px";
                         canvas_div.appendChild(blockParent);
                         canvas_div.appendChild(arrowParent);
 
-                        blockstemp[w].x = (blockParent.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(blockParent).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
-                        blockstemp[w].y = (blockParent.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(blockParent).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                        blockstemp[w].x = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(blockParent).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                        blockstemp[w].y = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(blockParent).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
                     }
                 }
                 blocks = blocks.concat(blockstemp);
@@ -352,8 +368,8 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                     childwidth: 0,
                     parent: blocko[i],
                     id: parseInt(drag.querySelector(".blockid").value),
-                    x: (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left,
-                    y: (drag.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top,
+                    x: (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left,
+                    y: (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top,
                     width: parseInt(window.getComputedStyle(drag).width),
                     height: parseInt(window.getComputedStyle(drag).height)
                 });
@@ -407,19 +423,19 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             if (hasParentClass(event.target, "block")) {
                 var theblock = event.target.closest(".block");
                 if (event.targetTouches) {
-                    mouse_x = event.targetTouches[0].clientX;
-                    mouse_y = event.targetTouches[0].clientY;
+                    mouse_x = event.targetTouches[0].clientX / zoom;
+                    mouse_y = event.targetTouches[0].clientY / zoom;
                 } else {
-                    mouse_x = event.clientX;
-                    mouse_y = event.clientY;
+                    mouse_x = event.clientX / zoom;
+                    mouse_y = event.clientY / zoom;
                 }
                 if (event.type !== "mouseup" && hasParentClass(event.target, "block")) {
                     if (event.which != 3) {
                         if (!active && !rearrange) {
                             dragblock = true;
                             drag = theblock;
-                            dragx = mouse_x - (drag.getBoundingClientRect().left + window.scrollX);
-                            dragy = mouse_y - (drag.getBoundingClientRect().top + window.scrollY);
+                            dragx = mouse_x - (scaled(drag.getBoundingClientRect()).left + window.scrollX);
+                            dragy = mouse_y - (scaled(drag.getBoundingClientRect()).top + window.scrollY);
                         }
                     }
                 }
@@ -435,11 +451,11 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
 
         flowy.moveBlock = function(event) {
             if (event.targetTouches) {
-                mouse_x = event.targetTouches[0].clientX;
-                mouse_y = event.targetTouches[0].clientY;
+                mouse_x = event.targetTouches[0].clientX / zoom;
+                mouse_y = event.targetTouches[0].clientY / zoom;
             } else {
-                mouse_x = event.clientX;
-                mouse_y = event.clientY;
+                mouse_x = event.clientX / zoom;
+                mouse_y = event.clientY / zoom;
             }
             if (dragblock) {
                 rearrange = true;
@@ -463,10 +479,10 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                             blockstemp.push(blocks.filter(a => a.id == layer[i].id)[0]);
                             const blockParent = document.querySelector(".blockid[value='" + layer[i].id + "']").parentNode;
                             const arrowParent = document.querySelector(".arrowid[value='" + layer[i].id + "']").parentNode;
-                            blockParent.style.left = (blockParent.getBoundingClientRect().left + window.scrollX) - (drag.getBoundingClientRect().left + window.scrollX) + "px";
-                            blockParent.style.top = (blockParent.getBoundingClientRect().top + window.scrollY) - (drag.getBoundingClientRect().top + window.scrollY) + "px";
-                            arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (drag.getBoundingClientRect().left + window.scrollX) + "px";
-                            arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) - (drag.getBoundingClientRect().top + window.scrollY) + "px";
+                            blockParent.style.left = (scaled(blockParent.getBoundingClientRect()).left + window.scrollX) - (scaled(drag.getBoundingClientRect()).left + window.scrollX) + "px";
+                            blockParent.style.top = (scaled(blockParent.getBoundingClientRect()).top + window.scrollY) - (scaled(drag.getBoundingClientRect()).top + window.scrollY) + "px";
+                            arrowParent.style.left = (arrowParent.getBoundingClientRect().left + window.scrollX) - (scaled(drag.getBoundingClientRect()).left + window.scrollX) + "px";
+                            arrowParent.style.top = (arrowParent.getBoundingClientRect().top + window.scrollY) - (scaled(drag.getBoundingClientRect()).top + window.scrollY) + "px";
                             drag.appendChild(blockParent);
                             drag.appendChild(arrowParent);
                             foundids.push(layer[i].id);
@@ -503,8 +519,8 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
             } else if (rearrange) {
                 drag.style.left = mouse_x - dragx - (window.scrollX + absx) + canvas_div.scrollLeft + "px";
                 drag.style.top = mouse_y - dragy - (window.scrollY + absy) + canvas_div.scrollTop + "px";
-                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value)).x = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft;
-                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value)).y = (drag.getBoundingClientRect().top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop;
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value)).x = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft;
+                blockstemp.filter(a => a.id == parseInt(drag.querySelector(".blockid").value)).y = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + (parseInt(window.getComputedStyle(drag).height) / 2) + canvas_div.scrollTop;
             }
             if (active || rearrange) {
                 if (mouse_x > canvas_div.getBoundingClientRect().width + canvas_div.getBoundingClientRect().left - 10 && mouse_x < canvas_div.getBoundingClientRect().width + canvas_div.getBoundingClientRect().left + 10) {
@@ -516,8 +532,8 @@ var flowy = function(canvas, grab, release, snapping, rearrange, spacing_x, spac
                 } else if (mouse_y < canvas_div.getBoundingClientRect().top + 10 && mouse_y > canvas_div.getBoundingClientRect().top - 10) {
                     canvas_div.scrollTop -= 10;
                 }
-                var xpos = (drag.getBoundingClientRect().left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
-                var ypos = (drag.getBoundingClientRect().top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
+                var xpos = (scaled(drag.getBoundingClientRect()).left + window.scrollX) + (parseInt(window.getComputedStyle(drag).width) / 2) + canvas_div.scrollLeft - canvas_div.getBoundingClientRect().left;
+                var ypos = (scaled(drag.getBoundingClientRect()).top + window.scrollY) + canvas_div.scrollTop - canvas_div.getBoundingClientRect().top;
                 var blocko = blocks.map(a => a.id);
                 for (var i = 0; i < blocks.length; i++) {
                     if (checkAttach(blocko[i])) {


### PR DESCRIPTION
## Summary

This PR ships a substantial upgrade to the Flowy demo — turning it into a fully featured PMM Agentic Workflow Designer with bug fixes, security hardening, a canvas zoom control, and a realistic branching starter flow.

## What changed

### Bug fixes (`engine/flowy.js`)
- **`rearrangeMe` position bug** — `r_array.y` was read/written on a filter array `[]` instead of `r_array[0]`, silently producing `NaN` positions after any rearrange
- **Bottom-edge auto-scroll axis** — wrote `scrollLeft` instead of `scrollTop` when cursor hit the bottom edge
- **`snap()` type mismatch** — parent assignment compared int to string without `parseInt`, could silently fail to find the block

### Security (`demo/main.js`)
- **XSS via innerHTML** — `hydrateBlock` and `buildStarterFlowImport` replaced innerHTML string interpolation with `createElement` + `textContent`
- **`drawArrow` innerHTML+=** — replaced with `insertAdjacentHTML` to avoid full DOM re-serialization on every arrow draw

### Canvas zoom feature (`engine/flowy.js`, `demo/main.js`, `demo/index.html`, `demo/styles.css`)
- Floating `− % + ⊡` pill at bottom-right of canvas
- Ctrl/Cmd + scroll wheel support; range 25%–200%, step 25%
- `flowy.setZoom(level)` + `scaled(rect)` helper divides all mouse coordinates and drag-element `getBoundingClientRect` calls by the zoom factor — drag-and-drop stays correct at any zoom level
- `canvas_div.getBoundingClientRect()` intentionally left unscaled (it's in screen space)

### `flowy.import()` improvements
- Added `skipRearrange` parameter — callers supplying pre-positioned HTML can opt out of the post-import `rearrangeMe()` pass that would otherwise overwrite custom positions

### 21-node branching starter flow (`demo/main.js`)
- Replaced linear 7-step placeholder with a trunk (8-step launch lifecycle) + 4 ongoing operational branches: competitive intel loop, content calendar loop, win/loss review loop, sales enablement ops loop
- `buildStarterFlowImport` rewritten with a recursive subtree-width centering layout engine (root at x=600 y=160, +220px per depth level, 320px sibling gap)

### Reliability
- `persist()` now calls `localStorage.removeItem()` on empty canvas instead of bailing silently
- `restore()` and JSON import `catch` blocks now log errors instead of swallowing them
- Properties form input debounced at 150ms
- `flowy.destroy()` added to remove all document-level event listeners
- Dead code removed: `addEventListenerMulti`, `removeEventListenerMulti`, unused `maxheight` vars

## Test plan
- [ ] Click **Build Starter Flow** — 21-node branching tree renders with trunk + 4 branches
- [ ] Zoom out to 50% with `−` button — full tree visible in viewport, label reads `50%`
- [ ] Ctrl+scroll on canvas zooms in/out
- [ ] Drag a block at 75% zoom — snaps correctly to parent
- [ ] Click **Clear Canvas** then refresh — canvas stays empty (localStorage cleared)
- [ ] Edit a step property — card updates, analytics refresh after ~150ms

🤖 Generated with [Claude Code](https://claude.ai/claude-code)